### PR TITLE
add .binstar.yml for anaconda build testing

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,79 @@
+
+## The package attribute specifies a binstar package namespace to build the package to.
+## This can be specified here or on the command line
+package: iamlp
+
+## You can also specify the account to upload to,
+## you must be an admin of that account, this
+## defaults to your user account
+user: psteinberg
+
+## You can give install_channels, the channels needed for
+## install and build.  For example, the r channel is needed for
+## r builds.  Channel 'defaults' is always added.
+# install_channels:
+#  - defaults
+
+#===============================================================================
+# Build Matrix Options
+# These options may be a single item, a list or empty
+# The resulting number of builds is [platform * engine * envvars]
+#===============================================================================
+
+## The platforms to build on.
+## platform defaults to linux-64
+platform:
+  - linux-64
+  - linux-32
+  - osx-64
+  - win-64
+  - win-32
+## The engine are the inital conda packages you want to run with
+engine:
+  - python=3.5
+## The envvars param is an environment variable list
+envvars:
+  - DASK_EXECUTOR=SERIAL LADSWEB_LOCAL_CACHE=.
+
+#===============================================================================
+# Script options
+# These options may be broken out into the before_script, script and after_script
+# or not, that is up to you
+#===============================================================================
+
+## Run before the script
+before_script:
+   - echo "before_script!"
+## Put your main computations here!
+script:
+  - echo "This is my binstar build!"
+  - conda env create
+  - activate iamlp # [win]
+  - source activate iamlp # [not win]
+  - python setup.py develop
+  - py.test
+## This will run after the script regardless of the result of script
+## BINSTAR_BUILD_RESULT=[succcess|failure]
+after_script:
+   - echo "The build was a $BINSTAR_BUILD_RESULT" | tee artifact1.txt
+## This will be run only after a successful build
+after_success:
+   - echo "after_success!"
+## This will be run only after a build failure
+after_failure:
+   - echo "after_failure!"
+
+#===============================================================================
+# Build Results
+# Build results are split into two categories: artifacts and targets
+# You may omit either key and stiff have a successful build
+# They may be a string, list and contain any bash glob
+#===============================================================================
+
+## Build Targets: Upload these files to your binstar package
+## build targets may be a list of files (globs allows) to upload
+## The special build targets 'conda' and 'pypi' may be used to
+## upload conda builds
+## e.g. conda is an alias for /opt/anaconda/conda-bld/<os-arch>/*.tar.bz2
+build_targets:
+   - conda

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -3,13 +3,11 @@ package:
   name: iamlp
   version: 0.0.0
 
-source:
-  git_rev: 0.0.0
-  git_url: https://github.com/ContinuumIO/nasasbir
-
 build:
   number: 0
   pin_depends: record
+  noarch_python: True
+
 
 requirements:
   build:


### PR DESCRIPTION
Just adds a .binstar.yml so there is CI testing via anaconda.org workers.

See:

[https://anaconda.org/psteinberg/iamlp/builds](https://anaconda.org/psteinberg/iamlp/builds)
