### PR TITLE
change anaconda org name to nasasbir not psteinberg

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -6,7 +6,7 @@ package: iamlp
 ## You can also specify the account to upload to,
 ## you must be an admin of that account, this
 ## defaults to your user account
-user: psteinberg
+user: nasasbir
 
 ## You can give install_channels, the channels needed for
 ## install and build.  For example, the r channel is needed for


### PR DESCRIPTION
Fix anaconda.org user name in .binstar.yml to be nasasbir not psteinberg.  When the package was set up, I did not have private package permissions yet for group nasasbir.
