### PR TITLE
add some json examples of train / predict pipelines

### DIFF
--- a/elm/example_configs/tested_config_BayesianRidge.yaml
+++ b/elm/example_configs/tested_config_BayesianRidge.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:BayesianRidge
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_BernoulliNB.yaml
+++ b/elm/example_configs/tested_config_BernoulliNB.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.naive_bayes:BernoulliNB
+    model_init_kwargs: {}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_BernoulliRBM.yaml
+++ b/elm/example_configs/tested_config_BernoulliRBM.yaml
@@ -1,0 +1,126 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.neural_network:BernoulliRBM
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: no_selection
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_DictionaryLearning.yaml
+++ b/elm/example_configs/tested_config_DictionaryLearning.yaml
@@ -1,0 +1,123 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:DictionaryLearning
+    model_init_kwargs: {alpha: 1, code_init: null, dict_init: null, fit_algorithm: lars,
+      max_iter: 1000, n_components: 1, n_jobs: 4, random_state: null, split_sign: false,
+      tol: 1.0e-07, transform_algorithm: omp, transform_alpha: null, transform_n_nonzero_coefs: null,
+      verbose: false}

--- a/elm/example_configs/tested_config_ElasticNet.yaml
+++ b/elm/example_configs/tested_config_ElasticNet.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:ElasticNet
+    model_init_kwargs: {max_iter: 10}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_ElasticNetCV.yaml
+++ b/elm/example_configs/tested_config_ElasticNetCV.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:ElasticNetCV
+    model_init_kwargs: {max_iter: 10, n_jobs: -1}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_FactorAnalysis.yaml
+++ b/elm/example_configs/tested_config_FactorAnalysis.yaml
@@ -1,0 +1,121 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:FactorAnalysis
+    model_init_kwargs: {copy: true, iterated_power: 3, max_iter: 1000, n_components: 1,
+      noise_variance_init: null, random_state: 0, svd_method: randomized, tol: 0.1}

--- a/elm/example_configs/tested_config_FastICA.yaml
+++ b/elm/example_configs/tested_config_FastICA.yaml
@@ -1,0 +1,121 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:FastICA
+    model_init_kwargs: {algorithm: parallel, fun: logcosh, fun_args: null, max_iter: 200,
+      n_components: 1, random_state: null, tol: 0.001, w_init: null, whiten: true}

--- a/elm/example_configs/tested_config_IncrementalPCA.yaml
+++ b/elm/example_configs/tested_config_IncrementalPCA.yaml
@@ -1,0 +1,120 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {batch_size: 1000, copy: true, n_components: 1, whiten: true}

--- a/elm/example_configs/tested_config_KernelPCA.yaml
+++ b/elm/example_configs/tested_config_KernelPCA.yaml
@@ -1,0 +1,122 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:KernelPCA
+    model_init_kwargs: {alpha: 1.0, coef0: 1, degree: 3, eigen_solver: dense, fit_inverse_transform: false,
+      gamma: null, kernel: linear, kernel_params: null, max_iter: null, n_components: 1,
+      remove_zero_eig: false, tol: 0}

--- a/elm/example_configs/tested_config_Lars.yaml
+++ b/elm/example_configs/tested_config_Lars.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:Lars
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LarsCV.yaml
+++ b/elm/example_configs/tested_config_LarsCV.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:LarsCV
+    model_init_kwargs: {max_iter: 10, n_jobs: -1}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_Lasso.yaml
+++ b/elm/example_configs/tested_config_Lasso.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:Lasso
+    model_init_kwargs: {max_iter: 10}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LassoCV.yaml
+++ b/elm/example_configs/tested_config_LassoCV.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:LassoCV
+    model_init_kwargs: {max_iter: 10, n_jobs: -1}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LassoLars.yaml
+++ b/elm/example_configs/tested_config_LassoLars.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:LassoLars
+    model_init_kwargs: {max_iter: 10}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LassoLarsCV.yaml
+++ b/elm/example_configs/tested_config_LassoLarsCV.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:LassoLarsCV
+    model_init_kwargs: {max_iter: 10, n_jobs: -1}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LassoLarsIC.yaml
+++ b/elm/example_configs/tested_config_LassoLarsIC.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:LassoLarsIC
+    model_init_kwargs: {max_iter: 10}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LatentDirichletAllocation.yaml
+++ b/elm/example_configs/tested_config_LatentDirichletAllocation.yaml
@@ -1,0 +1,123 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:LatentDirichletAllocation
+    model_init_kwargs: {batch_size: 1000, doc_topic_prior: null, evaluate_every: -1,
+      learning_decay: 0.7, learning_method: online, learning_offset: 10.0, max_doc_update_iter: 100,
+      max_iter: 10, mean_change_tol: 0.001, n_jobs: 4, n_topics: 2, perp_tol: 0.1,
+      random_state: null, topic_word_prior: null, total_samples: 1000000.0, verbose: 0}

--- a/elm/example_configs/tested_config_LinearDiscriminantAnalysis.yaml
+++ b/elm/example_configs/tested_config_LinearDiscriminantAnalysis.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.discriminant_analysis:LinearDiscriminantAnalysis
+    model_init_kwargs: {}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LinearRegression.yaml
+++ b/elm/example_configs/tested_config_LinearRegression.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:LinearRegression
+    model_init_kwargs: {n_jobs: -1}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_LogisticRegression.yaml
+++ b/elm/example_configs/tested_config_LogisticRegression.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:LogisticRegression
+    model_init_kwargs: {max_iter: 10, n_jobs: -1}
+    model_scoring: null
+    model_selection: null
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_MiniBatchKMeans.yaml
+++ b/elm/example_configs/tested_config_MiniBatchKMeans.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    get_y_func: null
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {max_iter: 10}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_MiniBatchSparsePCA.yaml
+++ b/elm/example_configs/tested_config_MiniBatchSparsePCA.yaml
@@ -1,0 +1,122 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:MiniBatchSparsePCA
+    model_init_kwargs: {alpha: 1, batch_size: 1000, callback: null, method: lars,
+      n_components: 1, n_iter: 100, n_jobs: 4, random_state: null, ridge_alpha: 0.01,
+      shuffle: true, verbose: false}

--- a/elm/example_configs/tested_config_MultinomialNB.yaml
+++ b/elm/example_configs/tested_config_MultinomialNB.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.naive_bayes:MultinomialNB
+    model_init_kwargs: {}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_NMF.yaml
+++ b/elm/example_configs/tested_config_NMF.yaml
@@ -1,0 +1,122 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:NMF
+    model_init_kwargs: {alpha: 0.0, beta: 1, eta: 0.1, init: null, l1_ratio: 0.0,
+      max_iter: 200, n_components: 1, nls_max_iter: 2000, random_state: null, shuffle: false,
+      solver: cd, sparseness: null, tol: 0.001, verbose: 0}

--- a/elm/example_configs/tested_config_OrthogonalMatchingPursuit.yaml
+++ b/elm/example_configs/tested_config_OrthogonalMatchingPursuit.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:OrthogonalMatchingPursuit
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_OrthogonalMatchingPursuitCV.yaml
+++ b/elm/example_configs/tested_config_OrthogonalMatchingPursuitCV.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:OrthogonalMatchingPursuitCV
+    model_init_kwargs: {max_iter: 10, n_jobs: -1}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_PCA.yaml
+++ b/elm/example_configs/tested_config_PCA.yaml
@@ -1,0 +1,120 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:PCA
+    model_init_kwargs: {copy: true, n_components: 1, whiten: true}

--- a/elm/example_configs/tested_config_PassiveAggressiveClassifier.yaml
+++ b/elm/example_configs/tested_config_PassiveAggressiveClassifier.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:PassiveAggressiveClassifier
+    model_init_kwargs: {n_jobs: -1}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_PassiveAggressiveRegressor.yaml
+++ b/elm/example_configs/tested_config_PassiveAggressiveRegressor.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:PassiveAggressiveRegressor
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_Perceptron.yaml
+++ b/elm/example_configs/tested_config_Perceptron.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:Perceptron
+    model_init_kwargs: {n_jobs: -1}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_ProjectedGradientNMF.yaml
+++ b/elm/example_configs/tested_config_ProjectedGradientNMF.yaml
@@ -1,0 +1,122 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:ProjectedGradientNMF
+    model_init_kwargs: {alpha: 0.0, beta: 1, eta: 0.1, init: null, l1_ratio: 0.0,
+      max_iter: 200, n_components: 1, nls_max_iter: 2000, random_state: null, solver: pg,
+      sparseness: null, tol: 0.001, verbose: 0}

--- a/elm/example_configs/tested_config_QuadraticDiscriminantAnalysis.yaml
+++ b/elm/example_configs/tested_config_QuadraticDiscriminantAnalysis.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.discriminant_analysis:QuadraticDiscriminantAnalysis
+    model_init_kwargs: {}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_RandomizedLasso.yaml
+++ b/elm/example_configs/tested_config_RandomizedLasso.yaml
@@ -1,0 +1,127 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:RandomizedLasso
+    model_init_kwargs: {max_iter: 10, n_jobs: -1, n_resampling: 2, pre_dispatch: 2*n_jobs,
+      sample_fraction: 0.2}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_RandomizedLogisticRegression.yaml
+++ b/elm/example_configs/tested_config_RandomizedLogisticRegression.yaml
@@ -1,0 +1,127 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:RandomizedLogisticRegression
+    model_init_kwargs: {n_jobs: -1, n_resampling: 2, pre_dispatch: 2*n_jobs, sample_fraction: 0.2}
+    model_scoring: null
+    model_selection: null
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_RandomizedPCA.yaml
+++ b/elm/example_configs/tested_config_RandomizedPCA.yaml
@@ -1,0 +1,121 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:RandomizedPCA
+    model_init_kwargs: {copy: true, iterated_power: 3, n_components: 1, random_state: null,
+      whiten: true}

--- a/elm/example_configs/tested_config_Ridge.yaml
+++ b/elm/example_configs/tested_config_Ridge.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:Ridge
+    model_init_kwargs: {max_iter: 10}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_RidgeCV.yaml
+++ b/elm/example_configs/tested_config_RidgeCV.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:RidgeCV
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_RidgeClassifier.yaml
+++ b/elm/example_configs/tested_config_RidgeClassifier.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:RidgeClassifier
+    model_init_kwargs: {max_iter: 10}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_RidgeClassifierCV.yaml
+++ b/elm/example_configs/tested_config_RidgeClassifierCV.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:RidgeClassifierCV
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: null
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_SGDClassifier.yaml
+++ b/elm/example_configs/tested_config_SGDClassifier.yaml
@@ -1,0 +1,131 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_binary
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:SGDClassifier
+    model_init_kwargs: {n_jobs: -1}
+    model_scoring: accuracy_score_cv
+    model_selection: select_top_n
+    model_selection_kwargs: {top_n: 1}
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_SGDRegressor.yaml
+++ b/elm/example_configs/tested_config_SGDRegressor.yaml
@@ -1,0 +1,130 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: elm.pipeline.tests.util:example_get_y_func_continuous
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: partial_fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+- predict: kmeans
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: partial_fit
+    keep_columns: []
+    model_init_class: sklearn.linear_model:SGDRegressor
+    model_init_kwargs: {}
+    model_scoring: null
+    model_selection: null
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_SparsePCA.yaml
+++ b/elm/example_configs/tested_config_SparsePCA.yaml
@@ -1,0 +1,122 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:SparsePCA
+    model_init_kwargs: {U_init: null, V_init: null, alpha: 1, max_iter: 1000, method: lars,
+      n_components: 1, n_jobs: 4, random_state: null, ridge_alpha: 0.01, tol: 1.0e-07,
+      verbose: false}

--- a/elm/example_configs/tested_config_SpectralClustering.yaml
+++ b/elm/example_configs/tested_config_SpectralClustering.yaml
@@ -1,0 +1,126 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {feature_selection: select_all}
+  - {random_sample: 500}
+  train: kmeans
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    ensemble_kwargs: {batches_per_gen: 1, init_ensemble_size: 2, n_generations: 1,
+      saved_ensemble_size: 1}
+    fit_kwargs: {}
+    fit_method: fit
+    keep_columns: []
+    model_init_class: sklearn.cluster:SpectralClustering
+    model_init_kwargs: {n_neighbors: 1}
+    model_scoring: null
+    model_selection: no_selection
+    output_tag: kmeans
+transform:
+  pca:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:IncrementalPCA
+    model_init_kwargs: {n_components: 2}
+    model_scoring: null
+    model_selection: null

--- a/elm/example_configs/tested_config_TruncatedSVD.yaml
+++ b/elm/example_configs/tested_config_TruncatedSVD.yaml
@@ -1,0 +1,121 @@
+DASK_EXECUTOR: SERIAL
+DASK_PROCESSES: null
+DASK_SCHEDULER: null
+DASK_THREADS: null
+LADSWEB_LOCAL_CACHE: null
+add_features: {}
+aggregations: {}
+change_detection:
+  time_series: []
+data_sources:
+  NPP_DSRF1KD_L2GD:
+    band_specs:
+    - [long_name, 'Band 1 ', band_1]
+    - [long_name, 'Band 2 ', band_2]
+    - [long_name, 'Band 3 ', band_3]
+    - [long_name, 'Band 4 ', band_4]
+    - [long_name, 'Band 5 ', band_5]
+    - [long_name, 'Band 7 ', band_7]
+    - [long_name, 'Band 8 ', band_8]
+    - [long_name, 'Band 10 ', band_10]
+    - [long_name, 'Band 11 ', band_11]
+    batch_size: 1440000
+    file_pattern: '*.hdf'
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: hdf4-eos
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs:
+      data_filter: null
+      filename_filter: null
+      geo_filters:
+        exclude_polys: []
+        include_polys: []
+      metadata_filter: null
+  S3_LANDSAT_L2_TIFS:
+    band_specs:
+    - [name, _B1.TIF, band_1]
+    - [name, _B2.TIF, band_2]
+    - [name, _B3.TIF, band_3]
+    - [name, _B4.TIF, band_4]
+    - [name, _B5.TIF, band_5]
+    - [name, _B6.TIF, band_6]
+    - [name, _B7.TIF, band_7]
+    - [name, _B9.TIF, band_9]
+    - [name, _B10.TIF, band_10]
+    - [name, _B11.TIF, band_11]
+    batch_size: 1440000
+    get_weight_func: null
+    get_weight_kwargs: {}
+    get_y_func: null
+    get_y_kwargs: {}
+    keep_columns: []
+    reader: dir_of_tifs_reader
+    sample_args_generator: tif_file_gen
+    sample_args_generator_kwargs: {top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+    sample_from_args_func: elm.sample_util.samplers:image_selection
+    selection_kwargs: {}
+ensembles:
+  no_ensemble: {batches_per_gen: 1, init_ensemble_size: 1, n_generations: 1, saved_ensemble_size: 1}
+  small_ensemble: {batches_per_gen: 4, init_ensemble_size: 16, n_generations: 4, saved_ensemble_size: 4}
+feature_selection:
+  select_all:
+    choices: all
+    kwargs: {}
+    scoring: chi2
+    scoring_kwargs: {}
+    selection: all
+masks: {}
+model_scoring:
+  accuracy_score_cv: {greater_is_better: true, needs_proba: false, needs_threshold: false,
+    scoring: accuracy_score, scoring_agg: 'numpy:median'}
+  ensemble_kmeans_scoring:
+    score_weights: [-1]
+    scoring: elm.model_selection.kmeans:ensemble_kmeans_scoring
+model_selection:
+  kmeans_model_averaging:
+    func: elm.model_selection.kmeans:kmeans_model_averaging
+    kwargs: {drop_n: 0, evolve_n: 1, init_n: 0}
+  select_top_n:
+    func: elm.model_selection.base:select_top_n_models
+    kwargs: {top_n: 1}
+pipeline:
+- method: fit
+  sample_pipeline:
+  - {random_sample: 1000}
+  transform: tested
+polys: {}
+predict:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    sample_args_generator: iter_files_recursively
+    sample_args_generator_kwargs: {extension: .hdf, top_dir: 'env:ELM_EXAMPLE_DATA_PATH'}
+readers:
+  dir_of_tifs_reader: {load_array: 'elm.readers.tif:load_dir_of_tifs_array', load_meta: 'elm.readers.tif:load_dir_of_tifs_meta'}
+  hdf4-eos: {load_array: 'elm.readers.hdf4:load_hdf4_array', load_meta: 'elm.readers.hdf4:load_hdf4_meta'}
+resamplers: {}
+sample_args_generators: {iter_files_recursively: 'elm.readers.local_file_iterators:iter_files_recursively',
+  tif_file_gen: 'elm.readers.local_file_iterators:iter_dirs_of_dirs'}
+train:
+  kmeans:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    fit_kwargs: {}
+    keep_columns: []
+    model_init_class: sklearn.cluster:MiniBatchKMeans
+    model_init_kwargs: {compute_labels: true}
+    model_scoring: ensemble_kmeans_scoring
+    model_selection: kmeans_model_averaging
+    output_tag: kmeans
+transform:
+  tested:
+    data_source: NPP_DSRF1KD_L2GD
+    ensemble: no_ensemble
+    model_init_class: sklearn.decomposition:TruncatedSVD
+    model_init_kwargs: {algorithm: randomized, n_components: 1, n_iter: 5, random_state: null,
+      tol: 0.0}


### PR DESCRIPTION
This PR adds some scenario yaml files which can be used for informal testing.

In serial:

```
$ ELM_LOGGING_LEVEL=DEBUG DASK_EXECUTOR=SERIAL elm-main --config tested_config_MiniBatchKMeans.yaml  --echo-config
```

In parallel:

```
ELM_LOGGING_LEVEL=DEBUG DASK_EXECUTOR=DISTRIBUTED DASK_SCHEDULER=10.0.0.10:8786   elm-main --config tested_config_MiniBatchKMeans.yaml  --echo-config
```

See `elm/example_configs`
