### PR TITLE
Add nightly_script.py

### DIFF
--- a/elm/scripts/run_all_tests.py
+++ b/elm/scripts/run_all_tests.py
@@ -172,13 +172,13 @@ def run_all_tests_remote_git_branch(args):
     return proc_wrapper(proc)
 
 
-def build_cli_parser(include_required=True):
+def build_cli_parser(include_positional=True):
     '''Return an argparse.ArgumentParser object which includes the arguments needed by this script.
 
     This function is also used by run_nightly.py.
     '''
     parser = ArgumentParser(description='Run longer-running tests of elm')
-    if include_required:
+    if include_positional:
         parser.add_argument('repo_dir', help='Directory that is the top dir of cloned elm repo')
         parser.add_argument('elm_configs_path', help='Path')
     parser.add_argument('--pytest-mark', help='Mark to pass to py.test -m (marker of unit tests)')

--- a/run_nightly.py
+++ b/run_nightly.py
@@ -3,44 +3,77 @@
 import os
 import datetime
 import argparse
+import subprocess as sp
+import tempfile
 import sys
+import shutil
+import atexit
 from elm.scripts import run_all_tests
 
 
-# Reuse the CLI parser from elm.scripts.run_all_tests
-parser = run_all_tests.build_cli_parser(include_required=False)
-args = parser.parse_args()
 
-# Provide the arguments which the user omitted
-if args.dask_clients is None:
-    args.dask_clients = ['SERIAL', 'DISTRIBUTED']
-if args.dask_scheduler is None:
-    args.dask_scheduler = 'localhost:8786'
-if args.remote_git_branch is None:
-    args.remote_git_branch = 'master'
-args.repo_dir = os.getcwd()
-args.elm_configs_path = os.path.join(args.repo_dir, 'example_configs')
+def reconstruct_cmdline(test_cmd, parser, args):
+    # Reconstruct command-line from parser and args
+    actions = {action.dest: action for action in parser._actions}
+    for arg, val in args._get_kwargs():
+        if actions[arg].const:
+            if val != actions[arg].default:
+                test_cmd += ' {}'.format(actions[arg].option_strings[0])
+        elif val is not None:
+            if isinstance(val, (list, tuple)):
+                val = ' '.join(val)
+            elif not isinstance(val, (str,)):
+                raise ValueError('Not sure how to handle argument value of type {}'.format(type(val)))
+            test_cmd += ' {} {}'.format(actions[arg].option_strings[0], val)
 
+    # Add positional arguments
+    positional_args = (os.getcwd(), os.path.join(os.getcwd(), 'example_configs'))
+    test_cmd += ' '+' '.join(positional_args)
 
-
-print('PWD = {}'.format(os.getcwd()))
-print('PATH = {}'.format(os.environ.get('PATH')))
-print('dask_clients = {}'.format(args.dask_clients))
-print('dask_scheduler = {}'.format(args.dask_scheduler))
-print('remote_git_branch = {}'.format(args.remote_git_branch))
-print('repo_dir = {}'.format(args.repo_dir))
-print('elm_configs_path = {}'.format(args.elm_configs_path))
+    return test_cmd
 
 
+def main():
+    # Reuse the CLI parser from elm.scripts.run_all_tests
+    parser = run_all_tests.build_cli_parser(include_positional=False)
+    args = parser.parse_args()
 
-# Run the nightly tests
-start_dt = datetime.datetime.now()
+    # Provide the arguments which the user omitted
+    if args.dask_clients is None:
+        args.dask_clients = ['SERIAL', 'DISTRIBUTED']
+    if args.dask_scheduler is None:
+        args.dask_scheduler = 'localhost:8786'
+    if args.remote_git_branch is None:
+        args.remote_git_branch = 'master'
+    #args.repo_dir = os.getcwd()
+    #args.elm_configs_path = os.path.join(args.repo_dir, 'example_configs')
 
-run_all_tests.run_all_tests(args)
-
-end_dt = datetime.datetime.now()
-print('\nSTART TIME: {}'.format(start_dt.isoformat()))
-print('\nEND TIME: {}'.format(end_dt.isoformat()))
+    test_cmd = reconstruct_cmdline('elm-run-all-tests', parser, args)
 
 
+    # Create a temporary directory for cloning/testing;
+    # Remove this directory automatically if the script exits.
+    tmp_dpath = tempfile.mkdtemp()
+    atexit.register(lambda: shutil.rmtree(tmp_dpath))
 
+    test_env_name = os.path.basename(tmp_dpath)
+    # The URL here needs to be git-based so that the SSH Deploy Key works
+    sp.check_call('git clone git@github.com:ContinuumIO/elm {}'.format(tmp_dpath), shell=True, executable='/bin/bash')
+    sp.check_call('git pull --all', shell=True, cwd=tmp_dpath, executable='/bin/bash')
+    sp.check_call('git checkout {}'.format(args.remote_git_branch), shell=True, cwd=tmp_dpath, executable='/bin/bash')
+    sp.check_call('conda env create -n {}'.format(test_env_name), shell=True, cwd=tmp_dpath, executable='/bin/bash')
+    sp.check_call('source activate {}'.format(test_env_name), shell=True, cwd=tmp_dpath, executable='/bin/bash')
+    sp.check_call('python setup.py develop', shell=True, cwd=tmp_dpath, executable='/bin/bash')
+
+    print('\n####\nTEST COMMAND:\n\t{}\n####\n'.format(test_cmd))
+
+    # Run the nightly tests
+    start_dt = datetime.datetime.now()
+    sp.check_call(test_cmd, shell=True, cwd=tmp_dpath, executable='/bin/bash')
+    end_dt = datetime.datetime.now()
+    print('\nSTART TIME: {}'.format(start_dt.isoformat()))
+    print('\nEND TIME: {}'.format(end_dt.isoformat()))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add nightly_script.py; it reuses the CLI-parsing-logic from `elm.scripts.run_all_tests`, which I factored out into a separate function.

Fix a few minor bugs which arose while linting `run_all_tests.py`. These were inside the `run_all_tests_remote_git_branch` function.
