### PR TITLE
ensure the time series methods have transform not just fit_transform

### DIFF
--- a/elm/sample_util/ts_grid_tools.py
+++ b/elm/sample_util/ts_grid_tools.py
@@ -172,6 +172,8 @@ class TSProbs(StepMixin):
         m = ModifySample(ts_probs, **self._kwargs)
         return (m.fit_transform(X)[0], y, sample_weight)
 
+    transform = fit = fit_transform
+
     def get_params(self):
         return self._kwargs.copy()
 
@@ -193,6 +195,8 @@ class TSDescribe(StepMixin):
         m = ModifySample(ts_describe, **self._kwargs)
         X_new = m.fit_transform(X)[0]
         return (X_new, y, sample_weight)
+
+    transform = fit = fit_transform
 
     def get_params(self):
         return self._kwargs.copy()


### PR DESCRIPTION
Small fix to time series statistics on grids - ensure the classes have a `transform` method, not just `fit_transform`