### PR TITLE
add an Intro and fix a number of broken links, formats

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,0 +1,49 @@
+About Ensemble Learning Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ensemble Learning Models (``elm`` ) is a set of tools for parallel ensemble unsupervised and supervised machine learning, with a focus on data structures useful in climate science and satellite imagery.
+
+.. _dask-distributed: http://distributed.readthedocs.io/en/latest/
+
+.. _xarray: http://xarray.pydata.org/en/stable/
+
+.. _scikit-learn: http://scikit-learn.org/stable/
+
+.. _estimator interface: http://scikit-learn.org/stable/developers/contributing.html#rolling-your-own-estimator
+
+.. _xarray data structures: http://xarray.pydata.org/en/stable/data-structures.html
+
+``elm`` Capabilities
+--------------------
+
+* :doc:`Ensemble learning<fit-ensemble>`
+* :doc:`Large scale prediction<predict-many>`
+* :doc:`Genetic algorithms<fit-ea>`
+* :doc:`Common preprocessing operations for satellite imagery and climate data<pipeline-steps>`
+
+These capabilities are best shown in the
+
+ * :doc:`Elm clustering introduction<clustering_example>`
+ * :doc:`Other elm examples<examples>`
+ * :doc:`Use cases<use-cases>`
+
+``elm`` wraps together the following Python packages:
+
+* `dask-distributed`_: ``elm`` uses `dask-distributed`_ for parallelism over ensemble fitting and prediction
+* `scikit-learn`_ : ``elm`` can use unsupervised and supervised models, preprocessors, scoring functions, and postprocessors from ``scikit-learn`` or any estimator that follows the `scikit-learn` initialize / fit / predict `estimator interface`_.
+* `xarray`_ : ``elm`` wraps `xarray data structures`_ for n-dimensional arrays, such as 3-dimensional weather cubes, and for collections of 2-D rasters, such as a LANDSAT sample
+
+``elm`` is a Work in Progress
+--------------------------
+``elm`` is immature and largely for experimental use.
+
+The developers do not promise backwards compatibility with future versions.
+
+Next steps
+----------
+
+.. _Try the example notebooks: http://github.com/ContinuumIO/elm-examples
+
+* :doc:`Install elm<install>`
+* `Try the example notebooks`_
+

--- a/docs/source/clustering_example.rst
+++ b/docs/source/clustering_example.rst
@@ -14,6 +14,8 @@ It demonstrates the common steps of using ``elm`` :
 
 .. _elm-data: http://github.com/ContinuumIO/elm-data
 
+.. AWS S3 LANDSAT bucket here: http://landsat-pds.s3.amazonaws.com/L8/015/033/LC80150332013207LGN00/index.html
+
 LANDSAT
 ~~~~~~~
 
@@ -23,7 +25,7 @@ The LANDSAT classification is notebook from `elm-examples`_ .  This section walk
  * How to set up an ``elm.pipeline.Pipeline`` of transformations
  * How to use ``dask`` to ``fit`` a ``Pipeline`` in ensemble and predict from many models
 
-**NOTE** : To follow along, make sure you follow the :ref:`Prerequisites`.
+**NOTE** : To follow along, make sure you follow the :ref:`Prerequisites`.  The LANDSAT sample used here can be found in the `AWS S3 LANDSAT bucket here`_.
 
 ``elm.readers`` Walk-Through
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/fit-ensemble.rst
+++ b/docs/source/fit-ensemble.rst
@@ -68,7 +68,7 @@ Next a :doc:`Pipeline<pipeline>` is configured that flattens the separate band r
 .. _signature for kmeans_aic: https://github.com/ContinuumIO/elm/blob/master/elm/model_selection/kmeans.py
 
 
-See the `signature for kmeans_aic`_ here to write a similar scoring function, otherwise ``scoring`` defaults to calling the estimator's ``.score` attribute.
+See the `signature for kmeans_aic`_ here to write a similar scoring function, otherwise ``scoring`` defaults to calling the estimator's ``.score`` callable or exception if ``.score`` is not defined.
 
 Configure Ensemble
 ------------------
@@ -93,6 +93,7 @@ Here's an example:
     }
 
 In the example above:
+
  * ``ngen`` sets the number of generations to 3
  * There are 4 initial ensemble members (``init_ensemble_size``),
  * After each generation ``kmeans_model_averaging`` (See :doc:`API docs<api>`) is called on the ensemble with ``model_selection_kwargs`` are passed.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,6 +4,7 @@ NASA SBIR Phase I - Open Source Parallel Image Analysis and Machine Learning Pip
 
 **Getting Started**
 
+* :doc:`about`
 * :doc:`install`
 * :doc:`use-cases`
 * :doc:`elm-hello-world.rst`
@@ -15,6 +16,7 @@ NASA SBIR Phase I - Open Source Parallel Image Analysis and Machine Learning Pip
    :hidden:
    :caption: Getting Started
 
+   about.rst
    install.rst
    use-cases.rst
    elm-hello-world.rst

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,15 +4,25 @@ Install ELM
 You can install elm with ``conda`` or by installing from source.
 
 Install from Conda
-~~~~~~
+~~~~~~~~~~~~~~~~~~
 
-To install the latest release of elm
+**Mac-OSX and Linux**: To install the latest release of ``elm`` on Mac-OSX or Linux:
 
 .. code-block:: bash
 
-    conda install -c elm -c conda-forge elm
+    conda create --name elm-env -c elm -c conda-forge elm python=3.5
+    source activate elm-env
 
-This installs elm and all common dependencies. The channel arguments (``c elm -c conda-forge`` ) are typically required.
+**Windows**: To install the latest release of ``elm`` on Windows:
+
+.. code-block:: bash
+
+    conda create --name elm-env -c elm -c conda-forge elm python=3.4
+    activate elm-env
+
+If you have any trouble, adjust the `python=3.4` to `python=3.5` as package availability may change in the future.
+
+This installs elm and all common dependencies. The channel arguments (``-c elm -c conda-forge`` ) are typically required.
 
 
 Install from Source

--- a/docs/source/predict-many.rst
+++ b/docs/source/predict-many.rst
@@ -1,7 +1,9 @@
 Example with :doc:`predict_many<predict-many>`
 ============
 
-``elm``'s :doc:`predict_many<predict-many>` predicts for each estimator in a trained ensemble for one or more samples. :doc:`predict_many<predict-many>` takes some of the same data source keyword arguments that :doc:`fit_ea<fit-ea>` and :doc:`fit_ensemble<fit-ensemble>` use.  See also Data Sources for a `Pipeline<pipeline>` - it discusses using a single sample by giving the keyword arguments ``X`` or giving a ``sampler`` and ``args_list`` (list of unpackable args to the ``sampler`` callable).  The same logic applies for :doc:`predict_many<predict-many>`.
+``elm``'s :doc:`predict_many<predict-many>` predicts for each estimator in a trained ensemble for one or more samples. :doc:`predict_many<predict-many>` takes some of the same data source keyword arguments that :doc:`fit_ea<fit-ea>` and :doc:`fit_ensemble<fit-ensemble>` use.  See also :doc:`Data Sources for a Pipeline<pipeline>` - it discusses using a single sample by giving the keyword arguments ``X`` or giving a ``sampler`` and ``args_list`` (list of unpackable args to the ``sampler`` callable).  The same logic applies for :doc:`predict_many<predict-many>`.
+
+.. _xarray-pcolormesh: http://xarray.pydata.org/en/stable/generated/xarray.plot.pcolormesh.html
 
 :doc:`predict_many<predict-many>` has a feature ``to_cube`` argument that is useful in prediction for spatial data.  ``to_cube=True`` (``True`` by default) means to convert the 1-D numpy array of predictions from the estimator of a :doc:`Pipeline<pipeline>` instance to a 2-D raster with the coordinates of the input data before the input data were flattened for training.  This makes it easy to make `xarray-pcolormesh`_ plots of predictions in spatial coordinates that are derived from models trained on spatial satellite and weather data.
 
@@ -28,7 +30,7 @@ This is a common set of ``import`` statements when working with ``elm``
 
 Define model selection
 ----------------------
-We can define a callable with a signature like ``model_selection`` below to control which models are passed from generation to generation in an ensemble.  This function just uses ``best_idxes`` (Pareto sorted model fitness from the ``accuracy_score`):
+We can define a callable with a signature like ``model_selection`` below to control which models are passed from generation to generation in an ensemble.  This function just uses ``best_idxes`` (Pareto sorted model fitness from the ``accuracy_score``):
 
 .. code-block:: python
 

--- a/docs/source/use-cases.rst
+++ b/docs/source/use-cases.rst
@@ -68,6 +68,7 @@ Hyperparameterization / Model Selection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``elm`` offers two different algorithms for multi-model training with model selection:
+
  * :doc:`fit_ensemble<fit-ensemble>`: Running one batch of models at a time (a generation), running a user-given model selection function after each generation
  * :doc:`fit_ea<fit-ea>`: Using the NSGA-2 evolutionary algorithm to select best parameters for the best fit.
 
@@ -118,8 +119,8 @@ Predicting for Many Large Samples and/or Models
 ``elm`` can use dask-distributed, a dask thread pool, or serial processing for predicting over a group (ensemble) of models and a single sample or series of samples.  ``elm``'s interface for large scale prediction, described here, is via the :doc:`predict_many<predict-many>` method of a ``Pipeline`` instance.
 
 
-``elm`` - Work in Progress
-~~~~~~~~~~~~~~~~
+``elm`` is a Work in Progress
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``elm`` is immature and largely for experimental use.
 
 The developers do not promise backwards compatibility with future versions.


### PR DESCRIPTION
* Adds an intro
* Fixes broken links
* Fixes a few minor formats
* Adds notes about python=3.4 or python=3.4 in install section (3.4 is typically Windows usage of Elm now while 3.5 is typical for posix)
* Adds note on original source of S3 LANDSAT data