### PR TITLE
Warnings fix plot fix

### DIFF
--- a/elm/sample_util/plotting_helpers.py
+++ b/elm/sample_util/plotting_helpers.py
@@ -5,6 +5,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 '''
+from collections import Sequence
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -30,7 +31,11 @@ def plot_3d(X, bands, title='', scale=None, axis_labels=True,
         val = getattr(X, band).values
         if idx == 0:
             arr = np.empty((val.shape) + (len(bands),), dtype=np.float32)
-        arr[:, :, idx] = val.astype(np.float64) / scale
+        if isinstance(scale, Sequence):
+            s = scale[idx]
+        else:
+            s = scale
+        arr[:, :, idx] = val.astype(np.float64) / s
     plt.imshow(arr, **imshow_kwargs)
     plt.title('{:^100}'.format(title))
     fig = plt.gcf()

--- a/elm/sample_util/sample_pipeline.py
+++ b/elm/sample_util/sample_pipeline.py
@@ -186,7 +186,7 @@ def check_array(arr, msg, **kwargs):
 
 
 def _has_arg(a):
-    return not (a is None or a == [] or (hasattr(a, 'size') and a.size == 0))
+    return not (a is None or (isinstance(a, list) and not a) or (hasattr(a, 'size') and a.size == 0))
 
 
 def final_on_sample_step(fitter,
@@ -259,9 +259,11 @@ def final_on_sample_step(fitter,
         logger.debug('X (shape {})'.format(X_values.shape))
     check_array(X_values, "final_on_sample_step - X")
     if has_y:
-        check_array(y, "final_on_sample_step - y")
+        if not y.size == X_values.shape[0]:
+            raise ValueError("Bad size for y ({}) - does not match X.shape[0] ({})".format(y.size, X_values.shape[0]))
     if has_sw:
-        check_array(sample_weight, 'final_on_sample_step - sample_weight')
+        if not sample_weight.size == X_values.shape[0]:
+            raise ValueError("Bad size for sample_weight ({}) - does not match X.shape[0] ({})".format(sample_weight.size, X_values.shape[0]))
     if 'batch_size' in model.get_params():
         logger.debug('set batch_size {}'.format(X_values.shape[0]))
         model.set_params(batch_size=X_values.shape[0])


### PR DESCRIPTION
* Make `ElmStore.plot_3d` 's `scale` argument allow a scalar or `Sequence` of 3 items.  `scale` is a divisor for the values of each band being passed as RGB to `imshow`.  In the case of `Sequence`, now a different scaling can be used for each of the 3 bands.
* Get rid of unnecessary warning caused by `check_array` being incorrectly called on 1-D arrays.