### PR TITLE
Add pipeline step for normalized differences, ratios, sums, diffs between bands

### DIFF
--- a/elm/pipeline/steps.py
+++ b/elm/pipeline/steps.py
@@ -33,3 +33,4 @@ from elm.sample_util.step_mixin import StepMixin
 from elm.sample_util.transform import Transform
 from elm.sample_util.change_coords import *
 from elm.sample_util.ts_grid_tools import *
+from elm.sample_util.bands_operation import *

--- a/elm/sample_util/bands_operation.py
+++ b/elm/sample_util/bands_operation.py
@@ -1,0 +1,46 @@
+from functools import partial
+
+import xarray as xr
+
+from elm.sample_util.change_coords import ModifySample
+
+def two_bands_operation(method, X, y=None, sample_weight=None, spec=None, **kwargs):
+    from elm.readers import ElmStore
+    bands = X.band_order.copy()
+    es = {}
+    if not spec:
+        raise ValueError('Expected "spec" in kwargs, e.g. {"ndvi": ["band_4", "band_3]}')
+    for idx, (key, (b1, b2)) in enumerate(sorted(spec.items())):
+        band1 = getattr(X, b1)
+        band2 = getattr(X, b2)
+        if method == 'normed_diff':
+            new = (band1 - band2) / (band1 + band2)
+        elif method == 'diff':
+            new = band1 - band2
+        elif method == 'sum':
+            new = band1 + band2
+        elif method == 'ratio':
+            new = band1 / band2
+        new.attrs.update(band1.attrs)
+        es[key] = new
+        bands.append(key)
+    Xnew = ElmStore(xr.merge([ElmStore(es, add_canvas=False), X]), add_canvas=False)
+    Xnew.attrs.update(X.attrs.copy())
+    Xnew.attrs['band_order'] = bands
+    return (Xnew, y, sample_weight)
+
+
+bands_normed_diff = partial(two_bands_operation, 'normed_diff')
+bands_diff = partial(two_bands_operation, 'diff')
+bands_sum = partial(two_bands_operation, 'sum')
+bands_ratio = partial(two_bands_operation, 'ratio')
+
+NormedBandsDiff = partial(ModifySample, func=bands_normed_diff)
+BandsDiff = partial(ModifySample, func=bands_diff)
+BandsSum = partial(ModifySample, func=bands_sum)
+BandsRatio = partial(ModifySample, func=bands_ratio)
+
+__all__ = ['NormedBandsDiff',
+           'BandsDiff',
+           'BandsSum',
+           'BandsRatio']

--- a/elm/sample_util/tests/test_bands_operation.py
+++ b/elm/sample_util/tests/test_bands_operation.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+
+from elm.pipeline.tests.util import random_elm_store
+from elm.sample_util.bands_operation import *
+
+def setup():
+    X = random_elm_store()
+    band1, band2 = (np.random.choice(X.band_order) for _ in range(2))
+    return X, band1, band2
+
+
+def test_diff():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = BandsDiff(spec=spec).fit_transform(X)
+    assert np.all(Xnew.abc.values == getattr(X, band1).values - getattr(X, band2).values)
+
+def test_normed_diff():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = NormedBandsDiff(spec=spec).fit_transform(X)
+    b1 = getattr(X, band1).values
+    b2 = getattr(X, band2).values
+    nd = (b1 - b2) / (b1 + b2)
+    assert np.all(Xnew.abc.values == nd)
+
+def test_sum():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = BandsSum(spec=spec).fit_transform(X)
+    assert np.all(Xnew.abc.values == getattr(X, band1).values + getattr(X, band2).values)
+
+def test_diff():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = BandsRatio(spec=spec).fit_transform(X)
+    assert np.all(Xnew.abc.values == getattr(X, band1).values / getattr(X, band2).values)

--- a/elm/sample_util/tests/test_bands_operation.py
+++ b/elm/sample_util/tests/test_bands_operation.py
@@ -31,7 +31,7 @@ def test_sum():
     Xnew, _, _ = BandsSum(spec=spec).fit_transform(X)
     assert np.all(Xnew.abc.values == getattr(X, band1).values + getattr(X, band2).values)
 
-def test_diff():
+def test_ratio():
     X, band1, band2 = setup()
     spec = dict(abc=(band1, band2))
     Xnew, _, _ = BandsRatio(spec=spec).fit_transform(X)


### PR DESCRIPTION
Adds `elm.pipeline.steps` classes for:

* Normalized differences between bands: `NormedBandsDiff`
* Difference between two bands `BandsDiff`
* Bands sum `BandsSum`
* Ratio between bands `BandsRatio`

