### PR TITLE
meta.yaml - version from env, python version 3.4,3.5

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: elm
-  version: 0.0.1
+  version: {{ environ['GIT_DESCRIBE_TAG'] }}
+
+source:
+  path: ..
 
 build:
   number: 0
@@ -11,8 +14,8 @@ requirements:
     - python
     - setuptools
   run:
-    - python x.x
-    - deap 
+    - python >=3.4
+    - deap
     - attrs
     - bokeh
     - dask


### PR DESCRIPTION
Fixes to the conda.recipe's meta.yaml:

 * Python version 3.4 or 3.5
 * Take version number from GIT_DESCRIBE_TAG