### PR TITLE
Add support for dev releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ dist: trusty
 matrix:
   global:
     - secure: "W/arbL8Ef3UMu1kTE/IzyLneId69DTtECr6O4GbBH4n4w7jJB/LZqkYJFsUsIbo0yZ48XxHAxkiFIjxiKSKjLW+evOzULu5n+hVNJlH+TFzngNfT2B/eiuWVTBs+aSAQpSO9gGjBoIHy5/2c0pPBecLPVb3dYIkk7AzxXKf/t2ZB+cKQtbZKa8muFjQ8a5cM1iaVc3j/3weAaywRnErV7BS8DdsfpsTLD4tYMHgE/c34YItUBRUqurUdgiETZA8Y+vJ+OzB42p25sTfZPpCJZ3DgR/3FCxo6dhaGs30H5wXX/kwBMF8B2lX6ZIo6MuwxOcSHp689ud6ydQ8s8LpjiFvLAA2Z1ra5J3BnkDcAcFxcnp7RRXSzQEkK4OD+nzLTsI9Ehtbnd8TE0wiUqj1c+4FRXZlm188dZvG3i4+8QPV/XY93xJntCzVgtGN6DsvqKxK86AtpLld7fRcO6+wQ/EwklROhGUYLPncZu9iAKE+J8s1seFSj7UCyMqYwCB8dbSKgRoOD/Py0BL+ou80V3aKRtdeGwOPssLDfGA288NWpU0lFkXwCzuZCzTU75kb2jt5dPXYVkjn/MDYa5GkGG5tP+YaC4Npa5V03aUdLCZ5W0ZI0CI8+j4H/bX3vgdWxrkokSvkDyIcpMRZ29w29rmMDHphbBRrJ84/b2jJHdTE="
+    - EARTHIO_VERSION=master
+    - EARTHIO_INSTALL_METHOD="conda"
+    - EARTHIO_TEST_ENV=earth-test-env
+    - ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
+    - EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
 
   include:
     - os: osx
@@ -28,12 +33,8 @@ branches:
     - master
 
 before_install:
-  - export EARTHIO_VERSION=master
-  - export EARTHIO_INSTALL_METHOD="conda"
-  - export EARTHIO_TEST_ENV=earth-test-env
-  - export ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
-  - export EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
-  - mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*
+  - mkdir -p $ELM_EXAMPLE_DATA_PATH
+  - rm -rf $ELM_EXAMPLE_DATA_PATH/*
 
 install:
   - MAKE_MINICONDA=1 . build_elm_env.sh
@@ -41,7 +42,6 @@ install:
 script:
   - cd $ELM_BUILD_DIR
   - . activate $EARTHIO_TEST_ENV
-  - echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
   - py.test -m 'not slow' -v
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
 
@@ -54,7 +54,8 @@ notifications:
 
 deploy:
   - provider: script
-    script: anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev $CONDA_PREFIX/../../conda-bld/linux-64/elm-*.tar.bz2
+    script:
+      - conda build $EARTHIO_CHANNEL_STR --output --python $PYTHON --numpy $NUMPY conda.recipe | xargs anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev
     #on:
     #  tags: true
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 script:
   - cd $ELM_BUILD_DIR
   - echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
-  - py.test -m 'not slow' -v
+  - $CONDA_PREFIX/bin/py.test -m 'not slow' -v
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
 
 notifications:
@@ -44,7 +44,7 @@ notifications:
 
 deploy:
   - provider: script
-    script: anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev $CONDA_PREFIX/../../conda-bld/linux-64/elm-*.tar.bz2
+    script: $CONDA_PREFIX/../../bin/anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev $CONDA_PREFIX/../../conda-bld/linux-64/elm-*.tar.bz2
     #on:
     #  tags: true
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ matrix:
     - env: PYTHON=3.4 NUMPY=1.10
     - env: PYTHON=2.7 NUMPY=1.9
 
+  # Support for these versions of Python is still a work-in-progress
+  allow_failures:
+    - env: PYTHON=3.6
+    - env: PYTHON=3.4
+    - env: PYTHON=2.7
+
+  # The build result is determined as soon as the required builds pass/fail
+  fast_finish: true
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,52 @@
+language: python
+
+python: 3.5
+
 dist: trusty
+
 matrix:
+  global:
+    - secure: "W/arbL8Ef3UMu1kTE/IzyLneId69DTtECr6O4GbBH4n4w7jJB/LZqkYJFsUsIbo0yZ48XxHAxkiFIjxiKSKjLW+evOzULu5n+hVNJlH+TFzngNfT2B/eiuWVTBs+aSAQpSO9gGjBoIHy5/2c0pPBecLPVb3dYIkk7AzxXKf/t2ZB+cKQtbZKa8muFjQ8a5cM1iaVc3j/3weAaywRnErV7BS8DdsfpsTLD4tYMHgE/c34YItUBRUqurUdgiETZA8Y+vJ+OzB42p25sTfZPpCJZ3DgR/3FCxo6dhaGs30H5wXX/kwBMF8B2lX6ZIo6MuwxOcSHp689ud6ydQ8s8LpjiFvLAA2Z1ra5J3BnkDcAcFxcnp7RRXSzQEkK4OD+nzLTsI9Ehtbnd8TE0wiUqj1c+4FRXZlm188dZvG3i4+8QPV/XY93xJntCzVgtGN6DsvqKxK86AtpLld7fRcO6+wQ/EwklROhGUYLPncZu9iAKE+J8s1seFSj7UCyMqYwCB8dbSKgRoOD/Py0BL+ou80V3aKRtdeGwOPssLDfGA288NWpU0lFkXwCzuZCzTU75kb2jt5dPXYVkjn/MDYa5GkGG5tP+YaC4Npa5V03aUdLCZ5W0ZI0CI8+j4H/bX3vgdWxrkokSvkDyIcpMRZ29w29rmMDHphbBRrJ84/b2jJHdTE="
+
   include:
-  - os: osx
-    env: PYTHON=3.6 NUMPY=1.12
-  - env: PYTHON=3.6 NUMPY=1.12
-  - env: PYTHON=3.5 NUMPY=1.11
-  - env: PYTHON=3.4 NUMPY=1.10
-  - env: PYTHON=2.7 NUMPY=1.9
+    - os: osx
+      env: PYTHON=3.6 NUMPY=1.12
+    - env: PYTHON=3.6 NUMPY=1.12
+    - env: PYTHON=3.5 NUMPY=1.11
+    - env: PYTHON=3.4 NUMPY=1.10
+    - env: PYTHON=2.7 NUMPY=1.9
+
 branches:
   only:
-  - master
+    - master
+
 before_install:
-- export EARTHIO_VERSION=master
-- export EARTHIO_INSTALL_METHOD="conda"
-- export EARTHIO_TEST_ENV=earth-test-env
-- export ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
-- export EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
-- mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*
+  - export EARTHIO_VERSION=master
+  - export EARTHIO_INSTALL_METHOD="conda"
+  - export EARTHIO_TEST_ENV=earth-test-env
+  - export ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
+  - export EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
+  - mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*
+
 install:
-- MAKE_MINICONDA=1 . build_elm_env.sh
+  - MAKE_MINICONDA=1 . build_elm_env.sh
+
 script:
-- cd $ELM_BUILD_DIR
-- echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
-- py.test -m 'not slow' -v
-- rm -rf $ELM_EXAMPLE_DATA_PATH/*
+  - cd $ELM_BUILD_DIR
+  - echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
+  - py.test -m 'not slow' -v
+  - rm -rf $ELM_EXAMPLE_DATA_PATH/*
+
 notifications:
   email: false
   on_success: change
   on_failure: always
   flowdock:
     secure: "ZWA9YrhDi9SQKSbjgEyl6cx1XgDDGASJz3PDOV+94kMjQpZvpTus+Z913wrpWw1FoerzieX5bDOM0gryszW6qHDrIg3eopFKGI+r9Hpm8pNxAN3PFwZMswpjE54yfVOLLVjW0/e9JbYtTUcn3mIwVIEHmzdiwI8CjPhrXs9B2r9c1YWWFi6iJIscrNvAirmiuTuPqzqxyF/MQK6VLwTJGRy3qmO1v/UfW3ohn4PDL1hUSZQTXcfsJQTmOlc2sJFO8VnzwN/phwck/XbNf8wFVROQm2J//PW9te8siwq/ttNk2ip7RYstvab16z1fQaeenZWiEz6GKEk2G3ZcItyA5SRdALHgObPWvbDAF+TUI42KG+WgiaC3qgxLw0hQNah+sFLUQIbI1salypE3u1lNIMgxj3PMLs0+WU1lQA49JvyOObL2oo62wPZB5p3vmhUBdIWpVjailH2fgpIYe/eZ7WQRPh0oUe8+xek1AER/mV1NyshOWz6MRvUUBT12gLgNM2n2Ogz2ixjP8VXoRECewXYjkLIOKahqxObQYwBGjFZKbNhBm4Adwc3KXXf6paYGpRDcbSyNNxZ7Tv/FyVgxnN2+O+FKKXfFgax9568Pzj1z4oqDLwXLpv2ecUYTVNPOlzjOGFc+IrGDbzr9PKn4SXsrLErc5xZKEXE6hNFywO8="
+
+deploy:
+  - provider: script
+    script: anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev $CONDA_PREFIX/../../conda-bld/linux-64/elm-*.tar.bz2
+    #on:
+    #  tags: true
+    skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,13 @@ env:
     - ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
     - EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
 
-matrix:
-  include:
-    - os: osx
-      env: PYTHON=3.6 NUMPY=1.12
-    - env: PYTHON=3.6 NUMPY=1.12
-    - env: PYTHON=3.5 NUMPY=1.11
-    - env: PYTHON=3.4 NUMPY=1.10
-    - env: PYTHON=2.7 NUMPY=1.9
+  matrix:
+    - PYTHON=3.6 NUMPY=1.12
+    - PYTHON=3.5 NUMPY=1.11
+    - PYTHON=3.4 NUMPY=1.10
+    - PYTHON=2.7 NUMPY=1.9
 
+matrix:
   # Support for these versions of Python is still a work-in-progress
   allow_failures:
     - env: PYTHON=3.6
@@ -56,7 +54,7 @@ notifications:
 deploy:
   - provider: script
     script:
-      - conda build $EARTHIO_CHANNEL_STR --output --python $PYTHON --numpy $NUMPY conda.recipe | xargs anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev
+      - conda build $EARTHIO_CHANNEL_STR --output --python $PYTHON --numpy $NUMPY conda.recipe | xargs anaconda upload -t ${BINSTAR_TOKEN} --user gbrener --label dev
     #on:
     #  tags: true
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-python: "3.5"
-
 dist: trusty
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 script:
   - cd $ELM_BUILD_DIR
   - echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
-  - $CONDA_PREFIX/bin/py.test -m 'not slow' -v
+  - py.test -m 'not slow' -v
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
 
 notifications:
@@ -44,7 +44,7 @@ notifications:
 
 deploy:
   - provider: script
-    script: $CONDA_PREFIX/../../bin/anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev $CONDA_PREFIX/../../conda-bld/linux-64/elm-*.tar.bz2
+    script: anaconda upload --token ${BINSTAR_TOKEN} --user elm --label dev $CONDA_PREFIX/../../conda-bld/linux-64/elm-*.tar.bz2
     #on:
     #  tags: true
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 dist: trusty
 
-matrix:
+env:
   global:
     - secure: "W/arbL8Ef3UMu1kTE/IzyLneId69DTtECr6O4GbBH4n4w7jJB/LZqkYJFsUsIbo0yZ48XxHAxkiFIjxiKSKjLW+evOzULu5n+hVNJlH+TFzngNfT2B/eiuWVTBs+aSAQpSO9gGjBoIHy5/2c0pPBecLPVb3dYIkk7AzxXKf/t2ZB+cKQtbZKa8muFjQ8a5cM1iaVc3j/3weAaywRnErV7BS8DdsfpsTLD4tYMHgE/c34YItUBRUqurUdgiETZA8Y+vJ+OzB42p25sTfZPpCJZ3DgR/3FCxo6dhaGs30H5wXX/kwBMF8B2lX6ZIo6MuwxOcSHp689ud6ydQ8s8LpjiFvLAA2Z1ra5J3BnkDcAcFxcnp7RRXSzQEkK4OD+nzLTsI9Ehtbnd8TE0wiUqj1c+4FRXZlm188dZvG3i4+8QPV/XY93xJntCzVgtGN6DsvqKxK86AtpLld7fRcO6+wQ/EwklROhGUYLPncZu9iAKE+J8s1seFSj7UCyMqYwCB8dbSKgRoOD/Py0BL+ou80V3aKRtdeGwOPssLDfGA288NWpU0lFkXwCzuZCzTU75kb2jt5dPXYVkjn/MDYa5GkGG5tP+YaC4Npa5V03aUdLCZ5W0ZI0CI8+j4H/bX3vgdWxrkokSvkDyIcpMRZ29w29rmMDHphbBRrJ84/b2jJHdTE="
     - EARTHIO_VERSION=master
@@ -11,6 +11,7 @@ matrix:
     - ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
     - EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
 
+matrix:
   include:
     - os: osx
       env: PYTHON=3.6 NUMPY=1.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
 matrix:
   # Support for these versions of Python is still a work-in-progress
   allow_failures:
-    - env: PYTHON=3.6
-    - env: PYTHON=3.4
-    - env: PYTHON=2.7
+    - env: PYTHON=3.6 NUMPY=1.12
+    - env: PYTHON=3.4 NUMPY=1.10
+    - env: PYTHON=2.7 NUMPY=1.9
 
   # The build result is determined as soon as the required builds pass/fail
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
 
 script:
   - cd $ELM_BUILD_DIR
+  - . activate $EARTHIO_TEST_ENV
   - echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
   - py.test -m 'not slow' -v
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,32 @@
-language: python
-
-python:
-  - "3.5"
-
-env:
-  - PYTHON_TEST_VERSION=2.7
-  - PYTHON_TEST_VERSION=3.5
-  - PYTHON_TEST_VERSION=3.6
-
+dist: trusty
+matrix:
+  include:
+  - os: osx
+    env: PYTHON=3.6 NUMPY=1.12
+  - env: PYTHON=3.6 NUMPY=1.12
+  - env: PYTHON=3.5 NUMPY=1.11
+  - env: PYTHON=3.4 NUMPY=1.10
+  - env: PYTHON=2.7 NUMPY=1.9
+branches:
+  only:
+  - master
+before_install:
+- export EARTHIO_VERSION=master
+- export EARTHIO_INSTALL_METHOD="conda"
+- export EARTHIO_TEST_ENV=earth-test-env
+- export ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
+- export EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
+- mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*
 install:
-  # The following control which earthio is part of build /test
-  - export EARTHIO_VERSION=master # branch or tag of earthio, ignored if using conda
-  # The following controls whether earthio is
-  # * installed from setup.py - use "git"
-  # * installed from conda build - use "conda"
-  - export EARTHIO_INSTALL_METHOD="conda" # or "conda"
-  # Name of test env
-  - export EARTHIO_TEST_ENV=earth-test-env
-  # Where is the test data stored - don't put it in elm or earthio folders
-  - export ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
-  # Which channels are required for installs of earthio and elm
-  - export EARTHIO_CHANNEL_STR=" -c ioam -c conda-forge -c scitools/label/dev "
-  - mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*
-  - MAKE_MINICONDA=1 . build_elm_env.sh
-
+- MAKE_MINICONDA=1 . build_elm_env.sh
 script:
-  - cd $ELM_BUILD_DIR
-  - echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
-  - py.test -m 'not slow' -v
-  - rm -rf $ELM_EXAMPLE_DATA_PATH/*
+- cd $ELM_BUILD_DIR
+- echo ELM_EXAMPLE_DATA_PATH is $ELM_EXAMPLE_DATA_PATH
+- py.test -m 'not slow' -v
+- rm -rf $ELM_EXAMPLE_DATA_PATH/*
+notifications:
+  email: false
+  on_success: change
+  on_failure: always
+  flowdock:
+    secure: "ZWA9YrhDi9SQKSbjgEyl6cx1XgDDGASJz3PDOV+94kMjQpZvpTus+Z913wrpWw1FoerzieX5bDOM0gryszW6qHDrIg3eopFKGI+r9Hpm8pNxAN3PFwZMswpjE54yfVOLLVjW0/e9JbYtTUcn3mIwVIEHmzdiwI8CjPhrXs9B2r9c1YWWFi6iJIscrNvAirmiuTuPqzqxyF/MQK6VLwTJGRy3qmO1v/UfW3ohn4PDL1hUSZQTXcfsJQTmOlc2sJFO8VnzwN/phwck/XbNf8wFVROQm2J//PW9te8siwq/ttNk2ip7RYstvab16z1fQaeenZWiEz6GKEk2G3ZcItyA5SRdALHgObPWvbDAF+TUI42KG+WgiaC3qgxLw0hQNah+sFLUQIbI1salypE3u1lNIMgxj3PMLs0+WU1lQA49JvyOObL2oo62wPZB5p3vmhUBdIWpVjailH2fgpIYe/eZ7WQRPh0oUe8+xek1AER/mV1NyshOWz6MRvUUBT12gLgNM2n2Ogz2ixjP8VXoRECewXYjkLIOKahqxObQYwBGjFZKbNhBm4Adwc3KXXf6paYGpRDcbSyNNxZ7Tv/FyVgxnN2+O+FKKXfFgax9568Pzj1z4oqDLwXLpv2ecUYTVNPOlzjOGFc+IrGDbzr9PKn4SXsrLErc5xZKEXE6hNFywO8="

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: 3.5
+python: "3.5"
 
 dist: trusty
 

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -5,37 +5,35 @@ export ELM_BUILD_DIR=`pwd -P`
 # using build_earthio_env.sh allows the
 # test data to be downloaded as well.
 build_elm_env(){
-    rm -rf .earthio_tmp;
-    git clone http://github.com/ContinuumIO/earthio .earthio_tmp && cd .earthio_tmp || return 1;
-    if [ "$EARTHIO_VERSION" = "" ];then
+    set -e
+    rm -rf .earthio_tmp
+    git clone http://github.com/ContinuumIO/earthio .earthio_tmp && cd .earthio_tmp
+    if [ "x$EARTHIO_VERSION" = "x" ]; then
         export EARTHIO_VERSION="master";
     fi
-    git fetch --all || return 1;
+    git fetch --all
     echo git checkout $EARTHIO_VERSION
-    git checkout $EARTHIO_VERSION || return 1;
-    conda config --set always_yes true;
-    . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV || return 1;
-    conda config --set always_yes true;
-    cd $ELM_BUILD_DIR || return 1;
+    git checkout $EARTHIO_VERSION
+    . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV
+    cd $ELM_BUILD_DIR
     # End of earthio and test data related section
-    if [ "$PYTHON" = "" ];then
+    if [ "x$PYTHON" = "x" ]; then
         echo FAIL - Must define PYTHON environment variable such as 2.7, 3.5 or 3.6 - FAIL
-        return 1;
+        return 1
     fi
-    conda update -n root conda || return 1;
-    conda remove -n root conda-build anaconda-client;
-    conda config --set anaconda_upload no;
-    conda remove elm &> /dev/null;
-    pip uninstall -y elm &> /dev/null;
-    cd $ELM_BUILD_DIR || return 1;
+    conda config --set always_yes true
+    conda update -n root conda conda-build
+    conda config --set anaconda_upload no
+    conda remove elm &> /dev/null
+    pip uninstall -y elm &> /dev/null
+    cd $ELM_BUILD_DIR
     echo conda list is ------
-    conda list || return 1;
+    conda list
     echo conda "env" list is ------
-    conda env list || return 1;
-    conda build $EARTHIO_CHANNEL_STR --python $PYTHON conda.recipe || return 1;
-    conda install $EARTHIO_CHANNEL_STR --use-local elm || return 1;
+    conda env list
+    conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
+    conda install $EARTHIO_CHANNEL_STR --use-local elm
+    set +e
 }
 
 build_elm_env && source activate $EARTHIO_TEST_ENV && echo OK
-
-

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -36,7 +36,7 @@ build_elm_env(){
     echo conda "env" list is ------
     conda env list
     conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
-    conda install $EARTHIO_CHANNEL_STR --use-local elm
+    conda install -n $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR --use-local elm
     set +e
 }
 

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -18,12 +18,13 @@ build_elm_env(){
     conda config --set always_yes true;
     cd $ELM_BUILD_DIR || return 1;
     # End of earthio and test data related section
-    if [ "$PYTHON_TEST_VERSION" = "" ];then
-        echo FAIL - Must define PYTHON_TEST_VERSION environment variable such as 2.7, 3.5 or 3.6 - FAIL
+    if [ "$PYTHON" = "" ];then
+        echo FAIL - Must define PYTHON environment variable such as 2.7, 3.5 or 3.6 - FAIL
         return 1;
     fi
     conda update -n root conda || return 1;
-    conda remove -n root conda-build;conda install -n root conda-build;
+    conda remove -n root conda-build anaconda-client;
+    conda config --set anaconda_upload no;
     conda remove elm &> /dev/null;
     pip uninstall -y elm &> /dev/null;
     cd $ELM_BUILD_DIR || return 1;
@@ -31,7 +32,7 @@ build_elm_env(){
     conda list || return 1;
     echo conda "env" list is ------
     conda env list || return 1;
-    conda build $EARTHIO_CHANNEL_STR --python $PYTHON_TEST_VERSION conda.recipe || return 1;
+    conda build $EARTHIO_CHANNEL_STR --python $PYTHON conda.recipe || return 1;
     conda install $EARTHIO_CHANNEL_STR --use-local elm || return 1;
 }
 

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -17,7 +17,7 @@ build_elm_env(){
     echo git checkout $EARTHIO_VERSION
     git checkout $EARTHIO_VERSION
     set +e
-    . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV
+    IGNORE_ELM_DATA_DOWNLOAD=1 . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV
     set -e
     cd $ELM_BUILD_DIR
     # End of earthio and test data related section

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -14,7 +14,9 @@ build_elm_env(){
     git fetch --all
     echo git checkout $EARTHIO_VERSION
     git checkout $EARTHIO_VERSION
+    set +x
     . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV
+    set -x
     cd $ELM_BUILD_DIR
     # End of earthio and test data related section
     if [ "x$PYTHON" = "x" ]; then

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -14,9 +14,9 @@ build_elm_env(){
     git fetch --all
     echo git checkout $EARTHIO_VERSION
     git checkout $EARTHIO_VERSION
-    set +x
+    set +e
     . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV
-    set -x
+    set -e
     cd $ELM_BUILD_DIR
     # End of earthio and test data related section
     if [ "x$PYTHON" = "x" ]; then

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -8,6 +8,8 @@ build_elm_env(){
     set -e
     rm -rf .earthio_tmp
     git clone http://github.com/ContinuumIO/earthio .earthio_tmp && cd .earthio_tmp
+    # Temporary fix
+    sed -i 's/PYTHON_TEST_VERSION/PYTHON/g' ./build_earthio_env.sh
     if [ "x$EARTHIO_VERSION" = "x" ]; then
         export EARTHIO_VERSION="master";
     fi

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -9,7 +9,7 @@ build_elm_env(){
     rm -rf .earthio_tmp
     git clone http://github.com/ContinuumIO/earthio .earthio_tmp && cd .earthio_tmp
     # Temporary fix
-    sed -i 's/PYTHON_TEST_VERSION/PYTHON/g' ./build_earthio_env.sh
+    sed -i.bak 's/PYTHON_TEST_VERSION/PYTHON/g' ./build_earthio_env.sh
     if [ "x$EARTHIO_VERSION" = "x" ]; then
         export EARTHIO_VERSION="master";
     fi
@@ -17,6 +17,8 @@ build_elm_env(){
     echo git checkout $EARTHIO_VERSION
     git checkout $EARTHIO_VERSION
     set +e
+    export PYTHON=${PYTHON:-3.5}
+    export NUMPY=${NUMPY:-1.11}
     IGNORE_ELM_DATA_DOWNLOAD=1 . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV
     set -e
     cd $ELM_BUILD_DIR
@@ -35,9 +37,8 @@ build_elm_env(){
     conda list
     echo conda "env" list is ------
     conda env list
-    pwd -P
     conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
-    conda install -n $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR --use-local elm
+    conda install $EARTHIO_CHANNEL_STR --use-local elm
     set +e
 }
 

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -35,6 +35,7 @@ build_elm_env(){
     conda list
     echo conda "env" list is ------
     conda env list
+    pwd -P
     conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
     conda install -n $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR --use-local elm
     set +e

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,6 +12,7 @@ requirements:
   build:
     - python
     - setuptools
+
   run:
     - attrs
     - deap


### PR DESCRIPTION
This PR includes the following:
- [x] Travis-CI build-matrix to test compatibility of different Python and NumPy versions
- [x] Automatic uploading of conda packages to anaconda.org and/or GitHub
  - [x] For Python 3.5
- [x] Travis-CI flowdock integrations
- [x] Skips Python versions that are not yet supported (for now)