### PR TITLE
add contributing guidelines and fix markdown links in index.rst

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,18 @@
+Contributing to ``elm``
+=======================
+
+.. _NASA Phase II SBIR summary here: https://sbir.gsfc.nasa.gov/SBIR/abstracts/16/sbir/phase1/SBIR-16-1-S5.03-7927.html
+
+.. _Waffle Board issue tracking system: https://waffle.io/ContinuumIO/elm/
+
+The goals for ``elm`` over the next 12 to 18 months are described in the `NASA Phase II SBIR summary here`_ regarding ``elm`` funding.  We welcome pull requests to ``elm`` from the community following the github forking model.  Please use the [github issues](https://github.com/ContinuumIO/elm/issues) for reporting problems or suggestions related to ``elm`` and see the `Waffle Board issue tracking system`_ for the status of several repositories related to ``elm`` .  Feel free to contact us (Continuum Analytics) for more information:
+
+ * Peter Steinberg psteinberg [at] continuum [dot] io
+ * Greg Brener gbrener [at] continuum [dot] io
+
+Related Information:
+
+ * :doc:`Installation<install>`
+ * :doc:`Releasing elm packcages<release>`
+ * :doc:`Testing<testing>`
+ * :doc:`Use Cases<use-cases>`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,8 +7,8 @@ NASA SBIR Phase I - Open Source Parallel Image Analysis and Machine Learning Pip
 * :doc:`about`
 * :doc:`install`
 * :doc:`use-cases`
-* :doc:`elm-hello-world.rst`
-* :doc:`clustering_example.rst`
+* :doc:`elm-hello-world`
+* :doc:`clustering_example`
 * :doc:`examples`
 
 .. toctree::


### PR DESCRIPTION
I noticed that 3 links were broken on index.rst in the docs markdown folder.  Two of them had `.rst` where it was not needed for markdown syntax, and in the other broken link, a reference to a file not there (`contributing.rst`).

 * Fixed links
 * Added `contributing.rst` with contact info for me and @gbrener 
