### PR TITLE
Supervised learning example: Census population and LANDSAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ target/
 # elm logs
 logfile.txt
 elapsed_time_test.txt
+
+examples/download_sample_data.py
+examples/datasets.yml
+examples/environment.yml
+examples/data

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
 
 install:
   - MAKE_MINICONDA=1 ./build_elm_env.sh
+  - export ELM_TOP_DIR=`pwd`
   - pushd docs
   - ~/miniconda/bin/conda env create -f environment.yml -n ${EARTHIO_TEST_ENV}-docs
   - source ~/miniconda/bin/activate ${EARTHIO_TEST_ENV}-docs
@@ -35,6 +36,7 @@ install:
 
 script:
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
+  - cd $ELM_TOP_DIR/examples && python dl_examples_env.py && conda env create -f environment.yml && conda env remove --name elm-examples
 
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   # The following ensures the env creation and file download
   # logic in ./examples can be run.  It only needs testing once
   # (not for each Python version of matrix)
-  - if [ "$PYTHON = "3.5" ]; then cd $ELM_BUILD_DIR/examples && conda create --name downloader-env python=3.5 requests yaml && source activate downloader-env && python dl_examples_env.py && conda env create -f environment.yml && conda env remove --name elm-examples; fi
+  - if [ "$PYTHON = "3.5" ]; then cd $ELM_BUILD_DIR/examples && conda create --name downloader-env python=3.5 requests yaml && source activate downloader-env && python dl_examples_env.py && conda env create -f environment.yml && conda env remove --name downloader-env; fi
 
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ install:
 
 script:
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
-  # The following ensures the env creation and file download
-  # logic in ./examples can be run.  It only needs testing once
-  # (not for each Python version of matrix)
-  - if [ "$PYTHON = "3.5" ]; then cd $ELM_BUILD_DIR/examples && conda create --name downloader-env python=3.5 requests yaml && source activate downloader-env && python dl_examples_env.py && conda env create -f environment.yml && conda env remove --name downloader-env; fi
 
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
 
 install:
   - MAKE_MINICONDA=1 ./build_elm_env.sh
-  - export ELM_TOP_DIR=`pwd`
   - pushd docs
   - ~/miniconda/bin/conda env create -f environment.yml -n ${EARTHIO_TEST_ENV}-docs
   - source ~/miniconda/bin/activate ${EARTHIO_TEST_ENV}-docs
@@ -36,7 +35,10 @@ install:
 
 script:
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
-  - cd $ELM_TOP_DIR/examples && python dl_examples_env.py && conda env create -f environment.yml && conda env remove --name elm-examples
+  # The following ensures the env creation and file download
+  # logic in ./examples can be run.  It only needs testing once
+  # (not for each Python version of matrix)
+  - if [ "$PYTHON = "3.5" ]; then cd $ELM_BUILD_DIR/examples && conda create --name downloader-env python=3.5 requests yaml && source activate downloader-env && python dl_examples_env.py && conda env create -f environment.yml && conda env remove --name elm-examples; fi
 
 notifications:
   on_success: change

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# elm examples
+
+## Setup
+
+```
+git clone https://github.com/ContinuumIO/elm.git
+cd elm/examples
+python dl_examples_env.py
+conda env create -f environment.yml
+source activate elm-examples
+```
+
+The script (in the first line) downloads the necessary files from the examples directory in [datashader's repository](https://github.com/bokeh/datashader) so that elm can download the example data and rely on a superset of its _environment.yml_. The lines after that use the modified _environment.yml_ to create an env called _elm-examples_, which may be used for running the example notebooks.
+
+## Running the notebook server
+
+The first time only, setup the config and password:
+```
+jupyter notebook --generate-config
+jupyter notebook password
+```
+Hitting <kbd>Enter</kbd> for the password should allow passwordless logins.
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,9 +8,10 @@ cd elm/examples
 python dl_examples_env.py
 conda env create -f environment.yml
 source activate elm-examples
+python download_sample_data.py
 ```
 
-The script (in the first line) downloads the necessary files from the examples directory in [datashader's repository](https://github.com/bokeh/datashader) so that elm can download the example data and rely on a superset of its _environment.yml_. The lines after that use the modified _environment.yml_ to create an env called _elm-examples_, which may be used for running the example notebooks.
+After the above commands finish, there should be a `elm/examples/data` directory with relevant data files.
 
 ## Running the notebook server
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,7 @@
 
 ## Setup
 
+First time only:
 ```
 git clone https://github.com/ContinuumIO/elm.git
 cd elm/examples
@@ -13,6 +14,13 @@ python download_sample_data.py
 
 After the above commands finish, there should be a `elm/examples/data` directory with relevant data files.
 
+On repeat runs, simply type:
+```
+source activate elm-examples
+```
+
+To add new datasets, edit the `datasets.yml` file and re-execute `download_sample_data.py`.
+
 ## Running the notebook server
 
 The first time only, setup the config and password:
@@ -20,5 +28,5 @@ The first time only, setup the config and password:
 jupyter notebook --generate-config
 jupyter notebook password
 ```
-Hitting <kbd>Enter</kbd> for the password should allow passwordless logins.
 
+Hitting <kbd>Enter</kbd> for the password should allow passwordless logins.

--- a/examples/dl_examples_env.py
+++ b/examples/dl_examples_env.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+
+import sys
+import os
+import requests
+import yaml
+from collections import OrderedDict
+
+
+ENV_SETUP_FILES = {
+    'download_sample_data.py': 'https://raw.githubusercontent.com/bokeh/datashader/master/examples/download_sample_data.py',
+    'datasets.yml': 'https://raw.githubusercontent.com/bokeh/datashader/master/examples/datasets.yml',
+    'environment.yml': 'https://raw.githubusercontent.com/bokeh/datashader/master/examples/environment.yml',
+}
+
+
+def dl_content(dst_fpath, url, tmpdir):
+    """Download content from url and save to dst_path."""
+    with open(os.path.join(tmpdir, dst_fpath), 'wb') as f:
+        resp = requests.get(url)
+        print('Downloading "{}"...'.format(url))
+        f.write(resp.content)
+
+
+def update_env_yml(fpath, tmpdir):
+    """Update environment.yml in tmpdir, and write the new version to current
+    directory.
+    """
+    print('Updating {} for elm...'.format(fpath))
+
+    # Preserve yaml ordering: https://stackoverflow.com/a/21048064
+    _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
+    def dict_representer(dumper, data):
+        return dumper.represent_dict(data.items())
+    def dict_constructor(loader, node):
+        return OrderedDict(loader.construct_pairs(node))
+    yaml.add_representer(OrderedDict, dict_representer)
+    yaml.add_constructor(_mapping_tag, dict_constructor)
+
+    with open(os.path.join(tmpdir, fpath), 'r') as fp:
+        env_data = OrderedDict(yaml.safe_load(fp))
+    env_data['name'] = 'elm-examples'
+    env_data['channels'].extend(['elm', 'elm/label/dev', 'numba'])
+
+    deps_to_add = ['earthio', 'elm']
+    deps = env_data['dependencies']
+    found_pip_deps = False
+    for pip_deps_idx, elt in enumerate(deps):
+        if isinstance(elt, dict) and 'pip' in elt:
+            found_pip_deps = True
+            break
+    if found_pip_deps:
+        env_data['dependencies'] = deps[:pip_deps_idx] + deps_to_add + deps[pip_deps_idx:]
+    else:
+        env_data['dependencies'].extend(deps_to_add)
+
+    with open(fpath, 'w') as fp:
+        yaml.dump(env_data, fp, default_flow_style=False)
+
+
+def main(argv):
+    # Download the environment setup files
+    for dst_fpath, url in ENV_SETUP_FILES.items():
+        dl_content(dst_fpath, url, '/tmp')
+
+    # Update the environment.yml for elm's examples
+    assert 'environment.yml' in ENV_SETUP_FILES
+    update_env_yml('environment.yml', '/tmp')
+
+    print('Finished downloading. Next steps:\n'
+          '    $ conda env create -f environment.yml\n'
+          '    $ source activate elm-examples\n'
+          '    $ python download_sample_data.py')
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/examples/dl_examples_env.py
+++ b/examples/dl_examples_env.py
@@ -45,7 +45,7 @@ def update_env_yml(fpath, tmpdir):
     env_data['name'] = 'elm-examples'
     env_data['channels'].extend(['elm', 'elm/label/dev', 'numba'])
 
-    deps_to_add = ['earthio', 'elm']
+    deps_to_add = ['earthio', 'elm','fastparquet', 'pyarrow']
     deps = env_data['dependencies']
     pip_deps_idx = None
     for deps_idx, elt in enumerate(deps):

--- a/examples/dl_examples_env.py
+++ b/examples/dl_examples_env.py
@@ -45,12 +45,13 @@ def update_env_yml(fpath, tmpdir):
 
     deps_to_add = ['earthio', 'elm']
     deps = env_data['dependencies']
-    found_pip_deps = False
-    for pip_deps_idx, elt in enumerate(deps):
+    pip_deps_idx = None
+    for deps_idx, elt in enumerate(deps):
         if isinstance(elt, dict) and 'pip' in elt:
-            found_pip_deps = True
-            break
-    if found_pip_deps:
+            pip_deps_idx = deps_idx
+        elif elt.startswith('python='):
+            env_data['dependencies'][deps_idx] = 'python=3.5'
+    if pip_deps_idx is not None:
         env_data['dependencies'] = deps[:pip_deps_idx] + deps_to_add + deps[pip_deps_idx:]
     else:
         env_data['dependencies'].extend(deps_to_add)


### PR DESCRIPTION
This is an example of both datashader and elm.  A few things to run this:

 * Copy this new elm/examples/LANDSAT-Population-Model.ipynb to datashader/examples
 * Modify the yaml of the datashader examples to include elm and earthio and Python 3.5 for now:
```
$ cat environment.yml
```
```
name: ds
channels:
 - bokeh/label/dev
 - conda-forge
 - ioam/label/dev
 - ioam
 - numba
 - scitools/label/dev
 - elm
 - elm/label/dev

dependencies:
 - attrs
 - bokeh>=0.12.6dev3
 - cartopy
 - colorcet
 - dask
 - datashader
 - dill
 - distributed
 - earthio
 - elm
 - pyarrow
 - fastparquet
 - geoviews
 - holoviews
 - iris
 - jupyter
 - krb5
 - matplotlib
 - networkx
 - numba
 - numpy
 - pandas
 - paramnb
 - pyproj
 - pytables
 - pytest
 - python=3.5
 - rasterio
 - requests
 - scikit-image
 - scipy
 - shapely
 - statsmodels
 - tblib
 - xarray
 - yaml
 - snappy
 - python-snappy
 - jupyter_dashboards
 - pip:
   - cachey
```

 * Then run the datashader example set up of creating the environment above and running `download_example_data.py`
 * `jupyter notebook` from the datashader/examples dir