### PR TITLE
Add compatibility for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
     - PYTHON=2.7 NUMPY=1.11
 
 matrix:
+  # A conda-build issue prevents Python 3.6 support
+  allow_failures:
+    - env: PYTHON=3.6 NUMPY=1.12
+
   # The build result is determined as soon as the required builds pass/fail
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,9 @@ env:
   matrix:
     - PYTHON=3.6 NUMPY=1.12
     - PYTHON=3.5 NUMPY=1.11
-    - PYTHON=2.7 NUMPY=1.9
+    - PYTHON=2.7 NUMPY=1.11
 
 matrix:
-  # Support for these versions of Python is still a work-in-progress
-  allow_failures:
-    - env: PYTHON=3.6 NUMPY=1.12
-    - env: PYTHON=2.7 NUMPY=1.9
-
   # The build result is determined as soon as the required builds pass/fail
   fast_finish: true
 

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -17,8 +17,6 @@ build_elm_env(){
     echo git checkout $EARTHIO_VERSION
     git checkout $EARTHIO_VERSION
     set +e
-    export PYTHON=${PYTHON:-3.5}
-    export NUMPY=${NUMPY:-1.11}
     IGNORE_ELM_DATA_DOWNLOAD=1 . build_earthio_env.sh && source activate $EARTHIO_TEST_ENV
     set -e
     cd $ELM_BUILD_DIR

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -26,8 +26,8 @@ build_elm_env(){
         return 1
     fi
     conda config --set always_yes true
-    conda install -n root conda conda-build==2.0.4
-    CONDA config --set anaconda_upload no
+    conda install -n root conda conda-build
+    conda config --set anaconda_upload no
     conda remove elm &> /dev/null
     pip uninstall -y elm &> /dev/null
     cd $ELM_BUILD_DIR

--- a/build_elm_env.sh
+++ b/build_elm_env.sh
@@ -28,8 +28,8 @@ build_elm_env(){
         return 1
     fi
     conda config --set always_yes true
-    conda update -n root conda conda-build
-    conda config --set anaconda_upload no
+    conda install -n root conda conda-build==2.0.4
+    CONDA config --set anaconda_upload no
     conda remove elm &> /dev/null
     pip uninstall -y elm &> /dev/null
     cd $ELM_BUILD_DIR

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - scipy
     - xarray
     - yaml
+    - six
 
 about:
   home: http://github.com/ContinuumIO/elm

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -50,4 +50,3 @@ test:
     - elm.pipeline.steps
     - elm.sample_util
     - elm.scripts
-

--- a/elm/config/cli.py
+++ b/elm/config/cli.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''Module of helpers for building command line interfaces'''
 from argparse import ArgumentParser
 

--- a/elm/config/config_info.py
+++ b/elm/config/config_info.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 This module loads elm/config/defaults/config_standard.yaml which
 is an elm config used for testing.

--- a/elm/config/dask_settings.py
+++ b/elm/config/dask_settings.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 dask_settings.py is a module of helpers for dask executors
 '''

--- a/elm/config/env.py
+++ b/elm/config/env.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''This module parses environment variables used by elm.
 
 See also elm/config/defaults/environment_vars_spec.yaml

--- a/elm/config/func_signatures.py
+++ b/elm/config/func_signatures.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------------
 

--- a/elm/config/load_config.py
+++ b/elm/config/load_config.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 This module is used by the command line interface of elm
 to parse yaml ensemble or evolutionary algorithm configs.
@@ -14,6 +16,8 @@ import numpy as np
 import sklearn.feature_selection as skfeat
 import sklearn.preprocessing as skpre
 import yaml
+
+from six import string_types
 
 try:
     from earthio.util import BandSpec
@@ -136,7 +140,7 @@ class ConfigParser(object):
         if callable(func_or_not):
             return func_or_not
         if func_or_not or (not func_or_not and required):
-            if not isinstance(func_or_not, str):
+            if not isinstance(func_or_not, string_types):
                 raise ElmConfigError('In {} expected {} to be a '
                                        'string'.format(func_or_not, context))
         return import_callable(func_or_not, required=required, context=context)
@@ -168,13 +172,13 @@ class ConfigParser(object):
         if not band_specs or not isinstance(band_specs, (tuple, list)):
             raise ElmConfigError('data_sources:{} gave band_specs which are not a '
                                    'list {}'.format(name, band_specs))
-        if not all(isinstance(bs, (dict, str)) for bs in band_specs):
+        if not all(isinstance(bs, (dict, string_types)) for bs in band_specs):
             raise ElmConfigError('Expected "band_specs" to be a list of dicts or list of strings')
 
         new_band_specs = []
         field_names = [x.name for x in attr.fields(BandSpec)]
         for band_spec in band_specs:
-            if isinstance(band_spec, str):
+            if isinstance(band_spec, string_types):
                 new_band_specs.append(BandSpec(**{'search_key': 'sub_dataset_name',
                                                 'search_value': band_spec,
                                                 'name': band_spec}))
@@ -188,7 +192,7 @@ class ConfigParser(object):
         '''Validate one data source within "data_sources"
         section of config'''
 
-        if not name or not isinstance(name, str):
+        if not name or not isinstance(name, string_types):
             raise ElmConfigError('Expected a "name" key in {}'.format(d))
         sampler = ds.get('sampler')
         if sampler:

--- a/elm/config/logging_config.py
+++ b/elm/config/logging_config.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import logging
 import os
 import sys

--- a/elm/config/tests/fixtures.py
+++ b/elm/config/tests/fixtures.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 
 import pytest
@@ -10,5 +12,4 @@ if bool(int(os.environ.get('IS_TRAVIS', 1))):
 
 else:
     @pytest.fixture(autouse=True)
-    def no_dask_distributed_on_travis(monkeypatch):
-        return
+        return    def no_dask_distributed_on_travis(monkeypatch):

--- a/elm/config/tests/fixtures.py
+++ b/elm/config/tests/fixtures.py
@@ -12,4 +12,5 @@ if bool(int(os.environ.get('IS_TRAVIS', 1))):
 
 else:
     @pytest.fixture(autouse=True)
-        return    def no_dask_distributed_on_travis(monkeypatch):
+    def no_dask_distributed_on_travis(monkeypatch):
+        return

--- a/elm/config/tests/test_config_simple.py
+++ b/elm/config/tests/test_config_simple.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import copy
 import os
 import pytest

--- a/elm/config/tests/test_config_simple.py
+++ b/elm/config/tests/test_config_simple.py
@@ -11,10 +11,19 @@ from elm.config.config_info import *
 from elm.config import ElmConfigError, ConfigParser
 from elm.config.tests.fixtures import *
 
-NOT_DICT = (2, 'abc', 2.2, [2,])
-NOT_INT = ({2:2}, [2, 2], 'abc', 2.2,)
-NOT_LIST = ({2:2}, 2, 2.2, 'abc')
-NOT_FUNCTION = 'not_an_importable_function:abc'
+from six import PY2
+
+# "Python 2 + unicode_literals" breaks the YAML parser
+if PY2:
+    NOT_DICT = (2, 'abc'.encode('utf-8'), 2.2, [2,])
+    NOT_INT = ({2:2}, [2, 2], 'abc'.encode('utf-8'), 2.2,)
+    NOT_LIST = ({2:2}, 2, 2.2, 'abc'.encode('utf-8'))
+    NOT_FUNCTION = 'not_an_importable_function:abc'.encode('utf-8')
+else:
+    NOT_DICT = (2, 'abc', 2.2, [2,])
+    NOT_INT = ({2:2}, [2, 2], 'abc', 2.2,)
+    NOT_LIST = ({2:2}, 2, 2.2, 'abc')
+    NOT_FUNCTION = 'not_an_importable_function:abc'
 
 def dump_config(config):
     tmp = tempfile.mkdtemp()

--- a/elm/config/util.py
+++ b/elm/config/util.py
@@ -7,7 +7,7 @@ import os
 import traceback
 import yaml
 
-from six import string_types
+from six import string_types, PY2
 
 
 EXAMPLE_CALLABLE = 'numpy:median'
@@ -61,7 +61,7 @@ def import_callable(func_or_not, required=True, context=''):
     module, func = func_or_not.split(':')
     try:
         # The import statement in Python 2 expects (decoded) str types instead of unicode strings
-        if six.PY2 and isinstance(func, unicode):
+        if PY2 and isinstance(func, unicode):
             func = func.encode('utf-8')
         mod = __import__(module, globals(), locals(), [func], 0)
     except Exception as e:

--- a/elm/config/util.py
+++ b/elm/config/util.py
@@ -60,6 +60,9 @@ def import_callable(func_or_not, required=True, context=''):
                                'e.g. {} but got {}'.format(context, EXAMPLE_CALLABLE, repr(func_or_not)))
     module, func = func_or_not.split(':')
     try:
+        # The import statement in Python 2 expects (decoded) str types instead of unicode strings
+        if six.PY2 and isinstance(func, unicode):
+            func = func.encode('utf-8')
         mod = __import__(module, globals(), locals(), [func], 0)
     except Exception as e:
         tb = traceback.format_exc()

--- a/elm/config/util.py
+++ b/elm/config/util.py
@@ -1,9 +1,13 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from pkg_resources import resource_stream, Requirement, resource_filename
 import json
 import os
 import traceback
 import yaml
+
+from six import string_types
 
 
 EXAMPLE_CALLABLE = 'numpy:median'
@@ -46,7 +50,7 @@ def import_callable(func_or_not, required=True, context=''):
     if callable(func_or_not):
         return func_or_not
     context = context + ' -  e' if context else 'E'
-    if func_or_not and (not isinstance(func_or_not, str) or func_or_not.count(':') != 1):
+    if func_or_not and (not isinstance(func_or_not, string_types) or func_or_not.count(':') != 1):
         raise ElmConfigError('{}xpected {} to be an module:callable '
                                'if given, e.g. {}'.format(context, repr(func_or_not), EXAMPLE_CALLABLE))
     if not func_or_not and not required:

--- a/elm/model_selection/base.py
+++ b/elm/model_selection/base.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------------
 

--- a/elm/model_selection/evolve.py
+++ b/elm/model_selection/evolve.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------------
 

--- a/elm/model_selection/kmeans.py
+++ b/elm/model_selection/kmeans.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------------
 

--- a/elm/model_selection/metrics.py
+++ b/elm/model_selection/metrics.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 import sklearn.metrics as sk_metrics
 

--- a/elm/model_selection/scoring.py
+++ b/elm/model_selection/scoring.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 --------------------------------
 

--- a/elm/model_selection/sklearn_support.py
+++ b/elm/model_selection/sklearn_support.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from __future__ import print_function
 from elm.config.util import import_callable
 from elm.config.func_signatures import get_args_kwargs_defaults

--- a/elm/model_selection/sorting.py
+++ b/elm/model_selection/sorting.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------------
 

--- a/elm/model_selection/tests/evolve_example_config.py
+++ b/elm/model_selection/tests/evolve_example_config.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 CONFIG_STR = '''
 ensembles: {
     save_one: {

--- a/elm/model_selection/tests/test_evolve.py
+++ b/elm/model_selection/tests/test_evolve.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import copy
 from io import StringIO
 from itertools import product

--- a/elm/pipeline/ensemble.py
+++ b/elm/pipeline/ensemble.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from functools import partial, wraps
 from itertools import chain, product
 import copy

--- a/elm/pipeline/evolve_train.py
+++ b/elm/pipeline/evolve_train.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from collections import Sequence
 from functools import partial
 from pprint import pformat

--- a/elm/pipeline/parse_run_config.py
+++ b/elm/pipeline/parse_run_config.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------
 
@@ -23,6 +25,8 @@ from elm.pipeline.pipeline import Pipeline
 from elm.pipeline.serialize import (serialize_prediction,
                                     serialize_pipe,
                                     load_pipe_from_tag)
+
+from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +60,7 @@ def config_to_pipeline(config, client=None):
             estimator = cls(**(train.get('model_init_kwargs') or {}))
             pipe_steps.append((step['train'], estimator))
             ensemble_kwargs = train.get('ensemble')
-            if isinstance(ensemble_kwargs, str):
+            if isinstance(ensemble_kwargs, string_types):
                 ensemble_kwargs = config.ensembles[ensemble_kwargs]
             ensemble_kwargs['client'] = client
         data_source = step['data_source']

--- a/elm/pipeline/pipeline.py
+++ b/elm/pipeline/pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------
 

--- a/elm/pipeline/predict_many.py
+++ b/elm/pipeline/predict_many.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from functools import partial
 import copy
 import datetime

--- a/elm/pipeline/serialize.py
+++ b/elm/pipeline/serialize.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------
 

--- a/elm/pipeline/steps.py
+++ b/elm/pipeline/steps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------
 
@@ -32,5 +34,4 @@ from elm.sample_util.preproc_scale import *
 from elm.sample_util.step_mixin import StepMixin
 from elm.sample_util.transform import Transform
 from elm.sample_util.change_coords import *
-from elm.sample_util.ts_grid_tools import *
-from elm.sample_util.bands_operation import *
+from elm.sample_util.bands_operation import *from elm.sample_util.ts_grid_tools import *

--- a/elm/pipeline/steps.py
+++ b/elm/pipeline/steps.py
@@ -34,4 +34,5 @@ from elm.sample_util.preproc_scale import *
 from elm.sample_util.step_mixin import StepMixin
 from elm.sample_util.transform import Transform
 from elm.sample_util.change_coords import *
-from elm.sample_util.bands_operation import *from elm.sample_util.ts_grid_tools import *
+from elm.sample_util.bands_operation import *
+from elm.sample_util.ts_grid_tools import *

--- a/elm/pipeline/tests/test_ensemble.py
+++ b/elm/pipeline/tests/test_ensemble.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 
 Tests usages like:
@@ -35,6 +37,8 @@ from elm.config.tests.fixtures import *
 from elm.pipeline import Pipeline, steps
 from elm.sample_util.make_blobs import random_elm_store
 from elm.model_selection.kmeans import kmeans_model_averaging, kmeans_aic
+
+from six import string_types
 
 ENSEMBLE_KWARGS = dict(ngen=2, init_ensemble_size=2,
                        saved_ensemble_size=2,
@@ -99,7 +103,7 @@ def _train_asserts(fitted, expected_len):
     ens = fitted.ensemble
     assert all(isinstance(x, tuple) and len(x) == 2 for x in ens)
     assert all(isinstance(x[1], Pipeline) for x in ens)
-    assert all(isinstance(x[0], str) and x[0] for x in ens)
+    assert all(isinstance(x[0], string_types) and x[0] for x in ens)
     assert len(fitted.ensemble) == expected_len
 
 

--- a/elm/pipeline/tests/test_evolve_train.py
+++ b/elm/pipeline/tests/test_evolve_train.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import copy
 from itertools import product
 import os

--- a/elm/pipeline/tests/test_pipeline.py
+++ b/elm/pipeline/tests/test_pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 This tests Pipeline:
  * Ensures pipe.fit_transform always returns X, y, sample_weight tuple,

--- a/elm/pipeline/tests/util.py
+++ b/elm/pipeline/tests/util.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 import contextlib
 import copy
@@ -20,6 +22,8 @@ import elm.sample_util.sample_pipeline as pipeline
 import elm.pipeline as elm_pipeline
 import elm.sample_util.transform as elmtransform
 from elm.scripts.main import main as elm_main
+
+from six import string_types
 
 old_ensemble = elm_pipeline.ensemble
 old_predict = elm_pipeline.predict_many
@@ -93,7 +97,7 @@ def example_get_y_func_continuous(flat_sample, **kwargs):
 
 def test_one_config(config=None, cwd=None):
 
-    if not isinstance(config, str):
+    if not isinstance(config, string_types):
         config_str = yaml.dump(config or DEFAULTS)
     else:
         config_str = config

--- a/elm/pipeline/util.py
+++ b/elm/pipeline/util.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------
 

--- a/elm/sample_util/band_selection.py
+++ b/elm/sample_util/band_selection.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ----------------------------------
 

--- a/elm/sample_util/band_selection.py
+++ b/elm/sample_util/band_selection.py
@@ -28,36 +28,35 @@ def _filename_filter(filename, search=None, func=None):
         keep = True
     if func is None:
         return keep
-    else:
-        return func(filename) and keep
+    return func(filename) and keep
 
 
 
-def select_from_file(*sampler_args,
-                     band_specs=None,
-                     metadata_filter=None,
-                     filename_filter=None,
-                     filename_search=None,
-                     dry_run=False,
-                     load_meta=None,
-                     load_array=None,
-                     **kwargs):
-
+def select_from_file(*sampler_args, **kwargs):
     '''select_from_file is the typical sampler used in the elm config
     file interface system via elm.pipeline.parse_run_config
 
     Parameters:
         :sampler_args: tuple of one element - a filename
-        :band_specs: list of band_specs included in a data_source
-        :metadata_filter: ignored
-        :filename_search: a search token for a filenames
-        :filename_filter: a function that returns True/False to keep filename
-        :dry_run:  if True, don't actually read file, just return True if accepted
-        :load_meta: Function, typically from earthio, to load metadata
-        :load_array: Function, typically from earthio, to load ElmStore
-        :kwargs: may contain "reader" such as "hdf4", "tif", "hdf5", "netcdf"
+        :band_specs: list of band_specs included in a data_source. default: None
+        :metadata_filter: ignored. default: None
+        :filename_search: a search token for a filenames. default: None
+        :filename_filter: a function that returns True/False to keep filename. default: None
+        :dry_run:  if True, don't actually read file, just return True if accepted. default: False
+        :load_meta: Function, typically from earthio, to load metadata. default: None
+        :load_array: Function, typically from earthio, to load ElmStore. default: None
+        :kwargs: (additional) may contain "reader" such as "hdf4", "tif", "hdf5", "netcdf"
 
     '''
+    kwargs = dict(
+        band_specs=None,
+        metadata_filter=None,
+        filename_filter=None,
+        filename_search=None,
+        dry_run=False,
+        load_meta=None,
+        load_array=None,
+    ).update(kwargs)
     filename = sampler_args[0]
     keep_file = _filename_filter(filename,
                                  search=filename_search,

--- a/elm/sample_util/bands_operation.py
+++ b/elm/sample_util/bands_operation.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from functools import partial
 
 import xarray as xr

--- a/elm/sample_util/bands_operation.py
+++ b/elm/sample_util/bands_operation.py
@@ -9,9 +9,13 @@ except:
     ElmStore = None # TODO handle case where earthio is not installed
 from elm.sample_util.change_coords import ModifySample
 
-def two_bands_operation(method, X, y=None, sample_weight=None, spec=None, **kwargs):
+from six import PY2
 
-    bands = X.band_order.copy()
+def two_bands_operation(method, X, y=None, sample_weight=None, spec=None, **kwargs):
+    if PY2:
+        bands = X.band_order[:]
+    else:
+        bands = X.band_order.copy()
     es = {}
     if not spec:
         raise ValueError('Expected "spec" in kwargs, e.g. {"ndvi": ["band_4", "band_3]}')
@@ -30,7 +34,8 @@ def two_bands_operation(method, X, y=None, sample_weight=None, spec=None, **kwar
         es[key] = new
         bands.append(key)
     Xnew = ElmStore(xr.merge([ElmStore(es, add_canvas=False), X]), add_canvas=False)
-    Xnew.attrs.update(X.attrs.copy())
+    xattrs_copy = X.attrs.copy()
+    Xnew.attrs.update(xattrs_copy)
     Xnew.attrs['band_order'] = bands
     return (Xnew, y, sample_weight)
 

--- a/elm/sample_util/change_coords.py
+++ b/elm/sample_util/change_coords.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ---------------------------------
 

--- a/elm/sample_util/make_blobs.py
+++ b/elm/sample_util/make_blobs.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from collections import OrderedDict
 
 from earthio import xy_canvas, ElmStore

--- a/elm/sample_util/plotting_helpers.py
+++ b/elm/sample_util/plotting_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ------------------------------------
 

--- a/elm/sample_util/polygon_tools.py
+++ b/elm/sample_util/polygon_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ---------------------------------
 

--- a/elm/sample_util/preproc_scale.py
+++ b/elm/sample_util/preproc_scale.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 --------------------------------
 
@@ -18,6 +20,8 @@ from elm.config import import_callable
 from elm.config.func_signatures import get_args_kwargs_defaults
 from elm.sample_util.step_mixin import StepMixin
 
+from six import string_types
+
 class SklearnBase(StepMixin):
     def __init__(self,  **kwargs):
         cls = getattr(skfeat, self.__class__.__name__, None)
@@ -30,7 +34,7 @@ class SklearnBase(StepMixin):
 
     def _import_score_func(self, **params):
         if 'score_func' in params:
-            if isinstance(params['score_func'], str):
+            if isinstance(params['score_func'], string_types):
                 sf = getattr(skfeat, params['score_func'], None)
                 if not sf:
                     sf = import_callable(params['score_func'])

--- a/elm/sample_util/sample_pipeline.py
+++ b/elm/sample_util/sample_pipeline.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     load_array = load_meta = None
 
-from six import string_types
+from six import string_types, PY2
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,10 @@ def make_pipeline_steps(config, pipeline):
             step_cls = action
         elif 'feature_selection' in action:
             _feature_selection = copy.deepcopy(config.feature_selection[action['feature_selection']])
-            kw = _feature_selection.copy()
+            if PY2:
+                kw = _feature_selection[:]
+            else:
+                kw = _feature_selection.copy()
             kw.update(action)
             scaler = _feature_selection['method']
             scaler = import_callable(getattr(skfeat, scaler, scaler))

--- a/elm/sample_util/sample_pipeline.py
+++ b/elm/sample_util/sample_pipeline.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     load_array = load_meta = None
 
-from six import string_types, PY2
+from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -122,10 +122,7 @@ def make_pipeline_steps(config, pipeline):
             step_cls = action
         elif 'feature_selection' in action:
             _feature_selection = copy.deepcopy(config.feature_selection[action['feature_selection']])
-            if PY2:
-                kw = _feature_selection[:]
-            else:
-                kw = _feature_selection.copy()
+            kw = _feature_selection.copy()
             kw.update(action)
             scaler = _feature_selection['method']
             scaler = import_callable(getattr(skfeat, scaler, scaler))

--- a/elm/sample_util/sample_pipeline.py
+++ b/elm/sample_util/sample_pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 -----------------------------------
 
@@ -31,6 +33,8 @@ try:
     from earthio import load_meta, load_array
 except ImportError:
     load_array = load_meta = None
+
+from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +85,7 @@ def create_sample_from_data_source(config=None, **data_source):
     if not isinstance(sampler_args, (tuple, list)):
         sampler_args = (sampler_args,)
     reader_name = data_source.get('reader') or None
-    if isinstance(reader_name, str) and reader_name:
+    if isinstance(reader_name, string_types) and reader_name:
         if config and reader_name in config.readers:
             reader = config.readers[reader_name]
         _load_meta = partial(load_meta, reader=reader_name)

--- a/elm/sample_util/samplers.py
+++ b/elm/sample_util/samplers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 -----------------------------
 

--- a/elm/sample_util/step_mixin.py
+++ b/elm/sample_util/step_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ---------------------------------
 

--- a/elm/sample_util/tests/test_bands_operation.py
+++ b/elm/sample_util/tests/test_bands_operation.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 
 from elm.config.tests.fixtures import *

--- a/elm/sample_util/tests/test_change_coords.py
+++ b/elm/sample_util/tests/test_change_coords.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 import xarray as xr
 

--- a/elm/sample_util/tests/test_feature_selection.py
+++ b/elm/sample_util/tests/test_feature_selection.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from earthio import ElmStore
 import numpy as np
 

--- a/elm/sample_util/tests/test_polygon_tools.py
+++ b/elm/sample_util/tests/test_polygon_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 # set to debug, will plot out polygons etc
 _DEBUG = False
 

--- a/elm/sample_util/tests/test_sample_pipeline.py
+++ b/elm/sample_util/tests/test_sample_pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import copy
 
 from earthio import ElmStore

--- a/elm/sample_util/tests/test_transform.py
+++ b/elm/sample_util/tests/test_transform.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from collections import OrderedDict
 import copy
 import glob

--- a/elm/sample_util/tests/test_ts_grid_tools.py
+++ b/elm/sample_util/tests/test_ts_grid_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 import pytest
 import xarray as xr

--- a/elm/sample_util/transform.py
+++ b/elm/sample_util/transform.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ---------------------------------
 

--- a/elm/sample_util/ts_grid_tools.py
+++ b/elm/sample_util/ts_grid_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 '''
 ---------------------------------
 

--- a/elm/scripts/main.py
+++ b/elm/scripts/main.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from argparse import ArgumentParser, Namespace
 import contextlib

--- a/elm/scripts/run_all_tests.py
+++ b/elm/scripts/run_all_tests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from argparse import Namespace, ArgumentParser
 import contextlib
 import glob
@@ -19,6 +21,7 @@ from elm.pipeline.tests.util import tmp_dirs_context, test_one_config
 from elm.scripts.main import main, cli
 from elm.config.env import parse_env_vars
 
+from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +46,7 @@ ETIMES = {}
 @contextlib.contextmanager
 def env_patch(**new_env):
     old_env = {k: v for k, v in os.environ.copy().items()
-               if k in new_env if isinstance(k, str)}
+               if k in new_env if isinstance(k, string_types)}
     try:
         os.environ.update({str(k): str(v) for k,v in new_env.items()})
         yield os.environ
@@ -53,7 +56,7 @@ def env_patch(**new_env):
 
 def print_status(s, context):
     global STATUS_COUNTER
-    if isinstance(s, str) and 'XFAIL' in s:
+    if isinstance(s, string_types) and 'XFAIL' in s:
         logger.info('TEST_XFAIL\t{}\t{}'.format(s, context))
         STATUS_COUNTER['xfail'] += 1
     if not s:

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
-name: elm-env-27
+name: elm-env
 channels:
  - conda-forge # essential for rasterio on osx
 dependencies:
- - python=2.7
+ - python
  - attrs
  - bokeh
  - dask

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
  - tblib
  - xarray
  - yaml
+ - six
  - pip:
    - deap==1.0.1
    - graphviz

--- a/examples/api_example.py
+++ b/examples/api_example.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import sys
 

--- a/examples/api_example_evo.py
+++ b/examples/api_example_evo.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import sys
 

--- a/examples/api_example_mods.py
+++ b/examples/api_example_mods.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import sys
 

--- a/examples/example_loikith_et_al.py
+++ b/examples/example_loikith_et_al.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import calendar
 from collections import OrderedDict
 import copy

--- a/run_nightly.py
+++ b/run_nightly.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import datetime
 import argparse
@@ -10,7 +12,7 @@ import shutil
 import atexit
 from elm.scripts import run_all_tests
 
-
+from six import string_types
 
 
 def reconstruct_cmdline(test_cmd, parser, args, elm_dir=os.getcwd(), examples_dir=os.path.join(os.getcwd())):
@@ -23,7 +25,7 @@ def reconstruct_cmdline(test_cmd, parser, args, elm_dir=os.getcwd(), examples_di
         elif val is not None:
             if isinstance(val, (list, tuple)):
                 val = ' '.join(val)
-            elif isinstance(val, (str,)):
+            elif isinstance(val, string_types):
                 val = '"{}"'.format(val)
             else:
                 raise ValueError('Not sure how to handle argument value of type {}'.format(type(val)))


### PR DESCRIPTION
Add compatibility for Python 2.7 by adding __future__ imports to each file, and six.string_types for isinstance(.., str) expressions. Also pin NumPy to be >=1.11 due to cartopy and datashader dependencies.