### PR TITLE
Ensure steps.DropNaRows() drops NA y when dropping rows from X

### DIFF
--- a/elm/sample_util/change_coords.py
+++ b/elm/sample_util/change_coords.py
@@ -114,7 +114,17 @@ class DropNaRows(StepMixin):
         '''
 
     def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
-        return (_drop_na_rows(X), y, sample_weight)
+        check_is_flat(X)
+        if y is not None:
+            if y.size != np.prod(y.shape) or y.size != X.flat.values.shape[0]:
+                msg = 'Found y size ({}) != X.flat.values.shape[0] ({})'
+                raise ValueError(msg.format(y.size, X.flat.values.shape[0]))
+        Xnew = _drop_na_rows(X)
+        if y is not None:
+            y = y[Xnew.flat.space.values]
+        if sample_weight is not None:
+            sample_weight = sample_weight[Xnew.space.values]
+        return (Xnew, y, sample_weight)
 
     transform = fit = fit_transform
 


### PR DESCRIPTION
A bug in `elm.pipeline.steps` resulted in `DropNaRows(X, y)` dropping NaN rows from the `X` matrix without dropping the corresponding rows from `y`.  The outcome was a dimension error on fitting.  I did not add a test for this fix.  I'll make a separate issue to better test:
 * supervised learning (this bug was discovered at this time because we have lower test/docs/examples coverage of supervised learning than unsupervised)
 * `elm.pipeline.steps.DropNaRows`

I am deferring the testing on those items above, rather than adding them to this PR, because we are about to start a 4 to 8 week major refactor of `elm.sample_util`, moving the `Pipeline` of filter functions like `DropNaRows` to `earthio.filters` (a new subpackage).   See also #149 for details on that refactor.