### PR TITLE
Documentation improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ install:
   - MAKE_MINICONDA=1 ./build_elm_env.sh
   - cd docs
   - ~/miniconda/bin/conda env update -f environment.yml -n $EARTHIO_TEST_ENV
-  - source activate $EARTHIO_TEST_ENV && make html && if [ "$TEST_DOCS" ]; then make doctest; fi
+  - source ~/miniconda/bin/activate $EARTHIO_TEST_ENV
+  - make html
+  - if [ "$TEST_DOCS" ]; then make doctest; fi
 
 script:
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,11 @@ before_install:
 install:
   - MAKE_MINICONDA=1 ./build_elm_env.sh
   - pushd docs
-  - ~/miniconda/bin/conda env update -f environment.yml -n $EARTHIO_TEST_ENV
-  - source ~/miniconda/bin/activate $EARTHIO_TEST_ENV
+  - ~/miniconda/bin/conda env create -f environment.yml -n ${EARTHIO_TEST_ENV}-docs
+  - source ~/miniconda/bin/activate ${EARTHIO_TEST_ENV}-docs
   - make html
   - if [ "$TEST_DOCS" ]; then make doctest; fi
+  - source deactivate
   - popd
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,12 @@ before_install:
 
 install:
   - MAKE_MINICONDA=1 ./build_elm_env.sh
-  - cd docs
+  - pushd docs
   - ~/miniconda/bin/conda env update -f environment.yml -n $EARTHIO_TEST_ENV
   - source ~/miniconda/bin/activate $EARTHIO_TEST_ENV
   - make html
   - if [ "$TEST_DOCS" ]; then make doctest; fi
+  - popd
 
 script:
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - ~/miniconda/bin/conda env create -f environment.yml -n ${EARTHIO_TEST_ENV}-docs
   - source ~/miniconda/bin/activate ${EARTHIO_TEST_ENV}-docs
   - make html
-  - if [ "$TEST_DOCS" ]; then make doctest; fi
+  - if [ "$TEST_DOCS" ]; then conda install --use-local elm earthio && make doctest; fi
   - source deactivate
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
   matrix:
     - PYTHON=3.6 NUMPY=1.12
-    - PYTHON=3.5 NUMPY=1.11
+    - PYTHON=3.5 NUMPY=1.11 TEST_DOCS=1
     - PYTHON=2.7 NUMPY=1.11
 
 matrix:
@@ -27,9 +27,7 @@ install:
   - MAKE_MINICONDA=1 ./build_elm_env.sh
   - cd docs
   - ~/miniconda/bin/conda env update -f environment.yml -n $EARTHIO_TEST_ENV
-  - source activate $EARTHIO_TEST_ENV
-  - make doctest
-  - make html
+  - source activate $EARTHIO_TEST_ENV && make html && if [ "$TEST_DOCS" ]; then make doctest; fi
 
 script:
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - ~/miniconda/bin/conda env create -f environment.yml -n ${EARTHIO_TEST_ENV}-docs
   - source ~/miniconda/bin/activate ${EARTHIO_TEST_ENV}-docs
   - make html
-  - if [ "$TEST_DOCS" ]; then conda install --use-local elm earthio && make doctest; fi
+  - if [ "$TEST_DOCS" ]; then conda install -c conda-forge -c ioam -c scitools --use-local elm earthio && make doctest; fi
   - source deactivate
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ before_install:
 
 install:
   - MAKE_MINICONDA=1 ./build_elm_env.sh
+  - cd docs
+  - ~/miniconda/bin/conda env update -f environment.yml -n $EARTHIO_TEST_ENV
+  - source activate $EARTHIO_TEST_ENV
+  - make doctest
+  - make html
 
 script:
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*

--- a/docs/autoreload_docs.py
+++ b/docs/autoreload_docs.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+
+import os
+import sys
+import shlex
+import argparse
+import threading
+import time
+import webbrowser
+from http.server import SimpleHTTPRequestHandler, test as serve
+
+from watchdog.watchmedo import parser as wdparser, shell_command
+
+
+# Monkey-patch SimpleHTTPRequestHandler to disable caching
+old_end_headers = SimpleHTTPRequestHandler.end_headers
+def end_headers_nocache(self):
+    """Monkey-patch the request handler to disable browser caching."""
+    self.send_header('Cache-Control', 'no-cache no-store must-revalidate')
+    self.send_header('Pragma', 'no-cache')
+    self.send_header('Expires', 0)
+    old_end_headers(self)
+
+
+def serve_sphinx(args):
+    """Launch http.server to run in a background thread."""
+    SimpleHTTPRequestHandler.end_headers = end_headers_nocache
+    serve(HandlerClass=SimpleHTTPRequestHandler, port=args.port, bind='0.0.0.0')
+
+
+def watch_sources():
+    """Launch watchdog to run in a background thread, rebuilding Sphinx docs on
+    file changes.
+    """
+    # Reuse the argparse instance from watchdog library
+    args = wdparser.parse_args(args=shlex.split('shell-command --patterns="*.rst" --ignore-patterns="build/*" --recursive --command="make html"'))
+    print('Watching for changes to files matching {} (excludes {})...'.format(args.patterns, args.ignore_patterns))
+    # Wait for sources to change; execute `--command` option when they do
+    shell_command(args)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='''
+1. Launch "python -m http.server $PORT" from the Sphinx output directory
+2. Watch Sphinx docs for changes
+3. Open web browser to see preview
+4. Sphinx automatically rebuilds when watcher sees changes
+''')
+    parser.add_argument('--port', '-p', type=int, default=6789)
+    args = parser.parse_args(args=argv[1:])
+
+    if not os.path.isdir('build/html'):
+        os.makedirs('build/html')
+
+    httpserver_thread = threading.Thread(target=serve_sphinx, args=[args])
+    watcher_thread = threading.Thread(target=watch_sources)
+
+    # Run the threads, with a slight delay in between so the http.server has
+    # enough time to start up (hacky, but works)
+    httpserver_thread.start()
+    time.sleep(1)
+    watcher_thread.start()
+
+    # Open tab in browser if not already open
+    webbrowser.open('http://localhost:{}/build/html'.format(args.port), new=0)
+
+    # Wait until threads terminate
+    watcher_thread.join()
+    httpserver_thread.join()
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/docs/autoreload_docs.py
+++ b/docs/autoreload_docs.py
@@ -34,7 +34,7 @@ def watch_sources():
     file changes.
     """
     # Reuse the argparse instance from watchdog library
-    args = wdparser.parse_args(args=shlex.split('shell-command --patterns="*.rst" --ignore-patterns="build/*" --recursive --command="make html"'))
+    args = wdparser.parse_args(args=shlex.split('shell-command --patterns="*.rst" --ignore-patterns="build/*" --recursive --command="rm -rf build/* && make html"'))
     print('Watching for changes to files matching {} (excludes {})...'.format(args.patterns, args.ignore_patterns))
     # Wait for sources to change; execute `--command` option when they do
     shell_command(args)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,7 @@ name: elm-docs
 channels:
   - conda-forge
 dependencies:
+  - python=3.5
   - sphinx
   - sphinx_rtd_theme
   - numpydoc

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,10 @@
+name: elm-docs
+channels:
+  - conda-forge
+dependencies:
+  - sphinx
+  - sphinx_rtd_theme
+  - numpydoc
+  - watchdog
+  - pip:
+    - recommonmark

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,0 @@
-recommonmark
-sphinx
-sphinx_rtd_theme
-numpydoc

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,47 +1,16 @@
 Why Elm?
 ~~~~~~~~
 
-Ensemble Learning Models (elm) is a set of tools for creating multiple unsupervised and supervised machine learning models and training them in parallel on datasets too large to fit into RAM on a single machine, with a focus on applications in climate science, GIS, and satellite imagery.
+Ensemble Learning Models (elm) is a set of tools for creating multiple unsupervised and supervised machine learning models and training them in parallel on datasets too large to fit into the RAM of a single machine, with a focus on applications in climate science, GIS, and satellite imagery.
 
 Some reasons for using elm over scikit-learn alone:
 
 - Parallelize ML pipelines across the cores of a single machine or compute cluster
-- Leverage out-of-core medium-to-large datasets, where data does not fit into RAM all at once
-- Work with N-dimensional climate data, instead of being limited to 2D representations
+- Use out-of-core ML algorithms to process large datasets which are too large to fit into RAM
+- Analyze multidimensional climate data, extending beyond the limitations of two-dimensional arrays and matrices
 - Read data from file formats popular to climate science and GIS, such as netCDF, HDF4, HDF5, Shapefiles, GeoJSON, and GeoTIFF
 
 More use-cases can be found `here <use-cases.html>`_.
-
-.. _dask-distributed: http://distributed.readthedocs.io/en/latest/
-
-.. _xarray: http://xarray.pydata.org/en/stable/
-
-.. _scikit-learn: http://scikit-learn.org/stable/
-
-.. _estimator interface: http://scikit-learn.org/stable/developers/contributing.html#rolling-your-own-estimator
-
-.. _xarray data structures: http://xarray.pydata.org/en/stable/data-structures.html
-
-``elm`` Capabilities
---------------------
-
-* :doc:`Ensemble learning<fit-ensemble>`
-* :doc:`Large scale prediction<predict-many>`
-* :doc:`Genetic algorithms<fit-ea>`
-* :doc:`Common preprocessing operations for satellite imagery and climate data<pipeline-steps>`
-
-These capabilities are best shown in the
-
- * :doc:`Elm introduction<elm-hello-world>`
- * :doc:`Elm clustering introduction<clustering_example>`
- * :doc:`Other elm examples<examples>`
- * :doc:`Use cases<use-cases>`
-
-``elm`` wraps together the following Python packages:
-
-* `dask-distributed`_: ``elm`` uses `dask-distributed`_ for parallelism over ensemble fitting and prediction
-* `scikit-learn`_ : ``elm`` can use unsupervised and supervised models, preprocessors, scoring functions, and postprocessors from ``scikit-learn`` or any estimator that follows the `scikit-learn` initialize / fit / predict `estimator interface`_.
-* `xarray`_ : ``elm`` wraps `xarray data structures`_ for n-dimensional arrays, such as 3-dimensional weather cubes, and for collections of 2-D rasters, such as a LANDSAT sample
 
 ``elm`` is a Work in Progress
 --------------------------
@@ -54,6 +23,7 @@ Next steps
 
 .. _Try the example notebooks: https://github.com/ContinuumIO/elm/tree/master/examples
 
+* :doc:`Use Cases for elm<use-cases>`
 * :doc:`Install elm<install>`
 * `Try the example notebooks`_
 

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,7 +1,16 @@
-About Ensemble Learning Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why Elm?
+~~~~~~~~
 
-Ensemble Learning Models (``elm`` ) is a set of tools for parallel ensemble unsupervised and supervised machine learning, with a focus on data structures useful in climate science and satellite imagery.
+Ensemble Learning Models (elm) is a set of tools for creating multiple unsupervised and supervised machine learning models and training them in parallel on datasets too large to fit into RAM on a single machine, with a focus on applications in climate science, GIS, and satellite imagery.
+
+Some reasons for using elm over scikit-learn alone:
+
+- Parallelize ML pipelines across the cores of a single machine or compute cluster
+- Leverage out-of-core medium-to-large datasets, where data does not fit into RAM all at once
+- Work with N-dimensional climate data, instead of being limited to 2D representations
+- Read data from file formats popular to climate science and GIS, such as netCDF, HDF4, HDF5, Shapefiles, GeoJSON, and GeoTIFF
+
+More use-cases can be found `here <use-cases.html>`_.
 
 .. _dask-distributed: http://distributed.readthedocs.io/en/latest/
 

--- a/docs/source/clustering_example.rst
+++ b/docs/source/clustering_example.rst
@@ -1,5 +1,5 @@
-``elm`` Overview / Example
-==========================
+Tutorials
+=========
 
 This page walks through a ``Jupyter`` notebook using ``elm`` to ensemble fit K-Means and predict from all members of the ensemble.
 

--- a/docs/source/elm-hello-world.rst
+++ b/docs/source/elm-hello-world.rst
@@ -18,6 +18,7 @@ First import model(s) from scikit-learn and ``Pipeline`` and ``steps`` from ``el
     from sklearn.cluster import AffinityPropagation
 
 .. testoutput::
+    :hide:
 
     <BLANKLINE>
 
@@ -124,14 +125,10 @@ Now we can use :doc:`fit_ensemble<fit-ensemble>` to fit to one or more samples a
 
 The code block with :doc:`fit_ensemble<fit-ensemble>` above would show the ``repr`` of the ``Pipeline`` object as follows:
 
-.. testcode:: quick-start
-
-    print(pipe)
-
-.. testoutput:: quick-start
+.. doctest:: quick-start
     :pyversion: == 3.5
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
+    >>> print(pipe)
     <elm.pipeline.Pipeline> with steps:
         flat: <elm.steps.Flatten>:
 
@@ -168,6 +165,7 @@ Step 4 - Call :doc:`predict_many<predict-many>`
 
 .. testoutput:: quick-start
     :pyversion: == 3.5
+    :hide:
     :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Enter with ['band_1', 'band_2', 'band_3', 'band_4', 'band_5', 'band_6', 'band_7', 'band_8', 'band_9', 'band_10'] None None 60 60
@@ -213,10 +211,15 @@ Step 4 - Call :doc:`predict_many<predict-many>`
 
 .. testcode:: quick-start
     :pyversion: == 3.5
-    :options: +SKIP
+
     import matplotlib.pyplot as plt
     example.predict.plot.pcolormesh()
     plt.show()
+
+.. testoutput:: quick-start
+    :pyversion: == 3.5
+    :hide:
+    :options: +SKIP
 
 -------------
 

--- a/docs/source/elm-hello-world.rst
+++ b/docs/source/elm-hello-world.rst
@@ -1,7 +1,7 @@
-``elm`` Intro
-=============
+Quick Start
+===========
 
-This tutorial is a Hello World example with ``elm``
+The following steps generate a visualization using `elm` on a synthetic dataset. As development on `elm` continues we strive to condense this document into a smaller example. For now, it offers insight into `elm`'s customizability and extensive feature set.
 
 Step 1 - Choose Model(s)
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,13 +61,11 @@ Now we can use :doc:`fit_ensemble<fit-ensemble>` to fit to one or more samples a
 
 .. code-block:: python
 
-    with client_context() as client:
-        pipe.fit_ensemble(sampler=sampler,
-                          args_list=args_list,
-                          client=client,
-                          init_ensemble_size=2,
-                          models_share_sample=False,
-                          ngen=1)
+    pipe.fit_ensemble(sampler=sampler,
+                      args_list=args_list,
+                      init_ensemble_size=2,
+                      models_share_sample=False,
+                      ngen=1)
 
 The code block with :doc:`fit_ensemble<fit-ensemble>` above would show the ``repr`` of the ``Pipeline`` object as follows:
 
@@ -103,8 +101,7 @@ Step 4 - Call :doc:`predict_many<predict-many>`
 .. code-block:: python
 
     import matplotlib.pyplot as plt
-    with client_context() as client:
-        preds = pipe.predict_many(sampler=sampler, args_list=args_list, client=client)
+    preds = pipe.predict_many(sampler=sampler, args_list=args_list)
     example = preds[0]
     example.predict.plot.pcolormesh()
     plt.show()

--- a/docs/source/elm-hello-world.rst
+++ b/docs/source/elm-hello-world.rst
@@ -8,13 +8,18 @@ Step 1 - Choose Model(s)
 
 First import model(s) from scikit-learn and ``Pipeline`` and ``steps`` from ``elm.pipeline``:
 
-.. code-block:: python
+.. testcode:: quick-start
+    :pyversion: == 3.5
 
     from elm.config import client_context
     from elm.sample_util.make_blobs import random_elm_store
     from elm.pipeline import Pipeline, steps
     from sklearn.decomposition import PCA
     from sklearn.cluster import AffinityPropagation
+
+.. testoutput::
+
+    <BLANKLINE>
 
 .. _an xarray.Dataset: http://xarray.pydata.org/en/stable/generated/xarray.Dataset.html
 
@@ -28,7 +33,8 @@ Step 2 - Define a ``sampler``
 
 If fitting more than one sample, then define a ``sampler`` function to pass to :doc:`fit_ensemble<fit-ensemble>`.  Here we are using a partial of ``random_elm_store`` (synthetic data). If using a ``sampler`` , we also need to define ``args_list`` a list of tuples where each tuple can be unpacked as arguments to ``sampler``.  The length of ``args_list`` determines the number of samples potentially used.  Here we have 2 empty tuples as ``args_list`` because our ``sampler`` needs no arguments and we want 2 samples.  Alternatively the arguments ``X`` , ``y`` , and ``sample_weight`` may be given in place of ``sampler`` and ``args_list`` .
 
-.. code-block:: python
+.. testcode:: quick-start
+    :pyversion: == 3.5
 
     from functools import partial
     N_SAMPLES = 2
@@ -39,6 +45,7 @@ If fitting more than one sample, then define a ``sampler`` function to pass to :
                       height=60)
     args_list = [(),] * N_SAMPLES
 
+
 Step 2 - Define a :doc:`Pipeline<pipeline>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -48,7 +55,8 @@ Step 2 - Define a :doc:`Pipeline<pipeline>`
 
 The code block below will use ``Flatten`` to convert each 2-D raster ( ``DataArray`` ) to give a single 1-D column in 2-D ``DataArray`` for machine learning.  The output of ``Flatten`` will be in turn passed to `sklearn.decomposition.PCA`_ and the reduced feature set from ``PCA`` will be passed to the `sklearn.cluster.AffinityPropagation`_ clustering model.
 
-.. code-block:: python
+.. testcode:: quick-start
+    :pyversion: == 3.5
 
     pipe = Pipeline([('flat', steps.Flatten()),
                      ('pca', steps.Transform(PCA())),
@@ -59,7 +67,8 @@ Step 3 - Call :doc:`fit_ensemble<fit-ensemble>` with ``dask``
 
 Now we can use :doc:`fit_ensemble<fit-ensemble>` to fit to one or more samples and one more instances of the ``pipe`` :doc:`Pipeline<pipeline>` above.  Below we are passing the ``sampler`` and ``args_list``, ``client``, which will be a ``dask-distributed`` or ``ThreadPool`` or None, depending on :doc:`environment variables<environment-vars>`. ``init_ensemble_size`` sets the number of :doc:`Pipeline<pipeline>` instances and ``models_share_sample=False`` means to fit all ``Pipeline`` / sample combinations (``2 X 2 == 4`` total members in this case).
 
-.. code-block:: python
+.. testcode:: quick-start
+    :pyversion: == 3.5
 
     pipe.fit_ensemble(sampler=sampler,
                       args_list=args_list,
@@ -67,9 +76,61 @@ Now we can use :doc:`fit_ensemble<fit-ensemble>` to fit to one or more samples a
                       models_share_sample=False,
                       ngen=1)
 
+.. testoutput:: quick-start
+    :pyversion: == 3.5
+    :hide:
+    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+
+    Enter with ['band_1', 'band_2', 'band_3', 'band_4', 'band_5', 'band_6', 'band_7', 'band_8', 'band_9', 'band_10'] None None 60 60
+    SHAPES 60 60 10 [[100 101 102 103 104 105 106 107 108 109]
+     [110 111 112 113 114 115 116 117 118 119]
+     [120 121 122 123 124 125 126 127 128 129]
+     [130 131 132 133 134 135 136 137 138 139]
+     [140 141 142 143 144 145 146 147 148 149]
+     [150 151 152 153 154 155 156 157 158 159]
+     [160 161 162 163 164 165 166 167 168 169]
+     [170 171 172 173 174 175 176 177 178 179]
+     [180 181 182 183 184 185 186 187 188 189]
+     [190 191 192 193 194 195 196 197 198 199]] [[ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]]
+    Enter with ['band_1', 'band_2', 'band_3', 'band_4', 'band_5', 'band_6', 'band_7', 'band_8', 'band_9', 'band_10'] None None 60 60
+    SHAPES 60 60 10 [[100 101 102 103 104 105 106 107 108 109]
+     [110 111 112 113 114 115 116 117 118 119]
+     [120 121 122 123 124 125 126 127 128 129]
+     [130 131 132 133 134 135 136 137 138 139]
+     [140 141 142 143 144 145 146 147 148 149]
+     [150 151 152 153 154 155 156 157 158 159]
+     [160 161 162 163 164 165 166 167 168 169]
+     [170 171 172 173 174 175 176 177 178 179]
+     [180 181 182 183 184 185 186 187 188 189]
+     [190 191 192 193 194 195 196 197 198 199]] [[ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]]
+
 The code block with :doc:`fit_ensemble<fit-ensemble>` above would show the ``repr`` of the ``Pipeline`` object as follows:
 
-.. code-block:: text
+.. testcode:: quick-start
+
+    print(pipe)
+
+.. testoutput:: quick-start
+    :pyversion: == 3.5
+    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     <elm.pipeline.Pipeline> with steps:
         flat: <elm.steps.Flatten>:
@@ -88,7 +149,8 @@ The code block with :doc:`fit_ensemble<fit-ensemble>` above would show the ``rep
 
 We can confirm that we have ``4`` :doc:`Pipeline<pipeline>` instances in the trained ensemble:
 
-.. code-block:: python
+.. doctest:: quick-start
+    :pyversion: == 3.5
 
     >>> len(pipe.ensemble)
     4
@@ -98,11 +160,61 @@ Step 4 - Call :doc:`predict_many<predict-many>`
 
 :doc:`predict_many<predict-many>` will by default predict from the ensemble that was just trained (4 models in this case).  :doc:`predict_many<predict-many>` takes ``sampler`` and ``args_list`` like :doc:`fit_ensemble<fit-ensemble>`.  The ``args_list`` may differ from that given to ``fit_ensemble`` or be the same.  We have 4 trained models in the ``.ensemble`` attribute of ``pipe`` and 2 samples specified by ``args_list`` , so :doc:`predict_many<predict-many>` returns a list of 8 prediction :doc:`ElmStore<elm-store>`s
 
-.. code-block:: python
+.. testcode:: quick-start
+    :pyversion: == 3.5
 
-    import matplotlib.pyplot as plt
     preds = pipe.predict_many(sampler=sampler, args_list=args_list)
     example = preds[0]
+
+.. testoutput:: quick-start
+    :pyversion: == 3.5
+    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+
+    Enter with ['band_1', 'band_2', 'band_3', 'band_4', 'band_5', 'band_6', 'band_7', 'band_8', 'band_9', 'band_10'] None None 60 60
+    SHAPES 60 60 10 [[100 101 102 103 104 105 106 107 108 109]
+     [110 111 112 113 114 115 116 117 118 119]
+     [120 121 122 123 124 125 126 127 128 129]
+     [130 131 132 133 134 135 136 137 138 139]
+     [140 141 142 143 144 145 146 147 148 149]
+     [150 151 152 153 154 155 156 157 158 159]
+     [160 161 162 163 164 165 166 167 168 169]
+     [170 171 172 173 174 175 176 177 178 179]
+     [180 181 182 183 184 185 186 187 188 189]
+     [190 191 192 193 194 195 196 197 198 199]] [[ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]]
+    Enter with ['band_1', 'band_2', 'band_3', 'band_4', 'band_5', 'band_6', 'band_7', 'band_8', 'band_9', 'band_10'] None None 60 60
+    SHAPES 60 60 10 [[100 101 102 103 104 105 106 107 108 109]
+     [110 111 112 113 114 115 116 117 118 119]
+     [120 121 122 123 124 125 126 127 128 129]
+     [130 131 132 133 134 135 136 137 138 139]
+     [140 141 142 143 144 145 146 147 148 149]
+     [150 151 152 153 154 155 156 157 158 159]
+     [160 161 162 163 164 165 166 167 168 169]
+     [170 171 172 173 174 175 176 177 178 179]
+     [180 181 182 183 184 185 186 187 188 189]
+     [190 191 192 193 194 195 196 197 198 199]] [[ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]
+     [ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]]
+
+.. testcode:: quick-start
+    :pyversion: == 3.5
+    :options: +SKIP
+    import matplotlib.pyplot as plt
     example.predict.plot.pcolormesh()
     plt.show()
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,5 +1,6 @@
 Examples
 ========
+
 This page provides examples of Python sessions using ``elm`` code and ``yaml`` config files that can be run with :doc:`elm-main<elm-main>`.
 
 .. _Prerequisites:

--- a/docs/source/fit-ea.rst
+++ b/docs/source/fit-ea.rst
@@ -1,5 +1,5 @@
-Fit EA
-======
+Multi-Model Fitting II: Evolutionary Algorithms
+===============================================
 
 ``elm`` can use an evolutionary algorithm for hyperparameterization.  This involves using the ``fit_ea`` method of :doc:`Pipeline<pipeline>`.  It is helpful at this point to first read about :doc:`Pipeline<pipeline>` and how to configure a data source for the multi-model approaches in ``elm``.  That page summarizes how :doc:`fit_ea<fit-ea>` and :doc:`fit_ensemble<fit-ensemble>` may be fit to a single ``X`` matrix (when the keyword ``X`` is given) or a series of samples (when ``sampler`` and ``args_list`` are given).
 

--- a/docs/source/fit-ensemble.rst
+++ b/docs/source/fit-ensemble.rst
@@ -1,5 +1,5 @@
-Fit Ensemble
-===========
+Multi-Model Fitting I: Ensemble Fitting
+=======================================
 
 Ensemble fitting may be helpful in cases where the representative sample is large and/or model parameter or fitting uncertainty should be considered.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,8 +5,8 @@ NASA SBIR Phase I & II - Open Source Parallel Image Analysis and Machine Learnin
 **Getting Started**
 
 * :doc:`about`
-* :doc:`install`
 * :doc:`use-cases`
+* :doc:`install`
 * :doc:`elm-hello-world`
 * :doc:`clustering_example`
 * :doc:`examples`
@@ -17,64 +17,35 @@ NASA SBIR Phase I & II - Open Source Parallel Image Analysis and Machine Learnin
    :caption: Getting Started
 
    about.rst
-   install.rst
    use-cases.rst
+   install.rst
    elm-hello-world.rst
    clustering_example.rst
    examples.rst
 
 
-**Concepts**
+**User Guide**
 
 * :doc:`elm-store`
 * :doc:`pipeline`
 * :doc:`pipeline-steps`
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Concepts
-
-   elm-store.rst
-   pipeline.rst
-   pipeline-steps.rst
-
-
-**Multi-Model Fitting**
-
 * :doc:`fit-ensemble`
 * :doc:`fit-ea`
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Multi-Model Fitting
-
-   fit-ensemble.rst
-   fit-ea.rst
-
-
-**Multi-Model Prediction**
-
 * :doc:`predict-many`
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Multi-Model Prediction
-
-   predict-many.rst
-
-**Train / Predict From Yaml Config**
-
 * :doc:`config-examples`
 * :doc:`elm-main`
 
 .. toctree::
    :maxdepth: 1
    :hidden:
-   :caption: Train / Predict from `yaml`
+   :caption: User Guide
 
+   elm-store.rst
+   pipeline.rst
+   pipeline-steps.rst
+   fit-ensemble.rst
+   fit-ea.rst
+   predict-many.rst
    config-examples.rst
    elm-main.rst
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
-=====================================================================================
-NASA SBIR Phase I - Open Source Parallel Image Analysis and Machine Learning Pipeline
-=====================================================================================
+==========================================================================================
+NASA SBIR Phase I & II - Open Source Parallel Image Analysis and Machine Learning Pipeline
+==========================================================================================
 
 **Getting Started**
 
@@ -24,7 +24,7 @@ NASA SBIR Phase I - Open Source Parallel Image Analysis and Machine Learning Pip
    examples.rst
 
 
-**Data Structures**
+**Concepts**
 
 * :doc:`elm-store`
 * :doc:`pipeline`
@@ -33,7 +33,7 @@ NASA SBIR Phase I - Open Source Parallel Image Analysis and Machine Learning Pip
 .. toctree::
    :maxdepth: 1
    :hidden:
-   :caption: Data Structures
+   :caption: Concepts
 
    elm-store.rst
    pipeline.rst

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,25 +1,56 @@
 Installation
 ============
 
-You can install elm with ``conda`` or by installing from source.
+There are two options for installing `elm`:
+
+    - :ref:`conda-install`
+    - :ref:`source-install`
+
+.. _conda-install:
 
 Install with Conda
 ~~~~~~~~~~~~~~~~~~
 
-To install the latest release of ``elm`` and ``earthio`` do:
+Conda is a package manager backed by `Continuum Analytics, Inc <http://continuum.io>`_. Notable features include first-class support for Python and R software that depends on C extensions, cross-platform support for Windows/Mac OSX/Linux, and standalone packages that are easy to distribute and deploy.
+
+Stable
+------
+
+The "stable" release is more thoroughly tested, but does not include the latest experimental features:
 
 .. code-block:: bash
 
-    conda create -c elm/label/dev -c elm -c conda-forge -c ioam -c conda-forge -c scitools/label/dev --name earth-env-35 python=3.5 elm earthio
+    conda create -c elm -c conda-forge -c ioam -c scitools --name earth-env elm earthio
 
-Note the command above uses the ``elm`` organization on `anaconda.org<http://anaconda.org>`_ and the command uses the ``dev`` label within that organization to get ``elm`` and the default ``main`` label for ``earthio`` .
+The above command creates a conda environment with the latest stable releases of `elm` and `earthio` installed. To begin using, activate the environment:
 
-This installs ``elm`` and ``earthio`` and all common dependencies. The channel arguments shown above may change with build system refactoring over the next few months.  If you encounter any issues with installation of the latest release from ``conda`` or source, then raise a github issue `in the elm repo here <http://github.com/ContinuumIO/elm/issues>`_ or email psteinberg [at] continuum [dot] io.
+.. code-block:: bash
+
+    source activate earth-env
+
+If you encounter any issues with installation of the latest release from ``conda`` or source, then raise a github issue `in the elm repo here <http://github.com/ContinuumIO/elm/issues>`_ or email psteinberg [at] continuum [dot] io.
+
+Development
+-----------
+
+The "development" releases are less stable, but include newer features:
+
+.. code-block:: bash
+
+    conda create -c elm/label/dev -c conda-forge -c ioam -c scitools/label/dev --name earth-env-dev python=3.5 elm earthio
+
+Like for the stable release, activate the environment to begin using `elm`:
+
+.. code-block:: bash
+
+    source activate earth-env-dev
+
+.. _source-install:
 
 Install from Source
 ~~~~~~~~~~~~~~~~~~~
 
-To install ``elm`` from `source <https://github.com/ContinuumIO/elm>`_ and quick check the install:
+Installing `elm` from source is recommended if you want to develop `elm` features and iterate rapidly over your code changes. To install ``elm`` from `source <https://github.com/ContinuumIO/elm>`_:
 
 .. code-block:: bash
 
@@ -27,9 +58,14 @@ To install ``elm`` from `source <https://github.com/ContinuumIO/elm>`_ and quick
     cd elm
     export ELM_EXAMPLE_DATA_PATH=~/elm-data
     PYTHON_TEST_VERSION=3.5 EARTHIO_INSTALL_METHOD=conda . build_elm_env.sh
+
+Verify the install with:
+
+.. code-block:: bash
+
     python -c "from earthio import *;from elm import *"
 
-Add the following ``ELM_EXAMPLE_DATA_PATH`` to your .bashrc or environment to avoid >1 download of the test data and have the test data discovered by ``py.test``:
+You may want to add the following line to your .bashrc (or equivalent shell config) to avoid >1 download of the test data and have the test data discovered by ``py.test``:
 
 .. code-block:: bash
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,9 +1,9 @@
-Install ELM
-===========
+Installation
+============
 
 You can install elm with ``conda`` or by installing from source.
 
-Install from Conda
+Install with Conda
 ~~~~~~~~~~~~~~~~~~
 
 To install the latest release of ``elm`` and ``earthio`` do:

--- a/docs/source/pipeline-steps.rst
+++ b/docs/source/pipeline-steps.rst
@@ -1,5 +1,5 @@
-``elm.pipeline.steps``
-======================
+Customizable Pipeline Steps
+===========================
 
 The examples below assume you have created a random :doc:`ElmStore<elm-store>` as follows:
 

--- a/docs/source/predict-many.rst
+++ b/docs/source/predict-many.rst
@@ -1,5 +1,5 @@
-Example with :doc:`predict_many<predict-many>`
-============
+Multi-Model Prediction
+======================
 
 ``elm``'s :doc:`predict_many<predict-many>` predicts for each estimator in a trained ensemble for one or more samples. :doc:`predict_many<predict-many>` takes some of the same data source keyword arguments that :doc:`fit_ea<fit-ea>` and :doc:`fit_ensemble<fit-ensemble>` use.  See also :doc:`Data Sources for a Pipeline<pipeline>` - it discusses using a single sample by giving the keyword arguments ``X`` or giving a ``sampler`` and ``args_list`` (list of unpackable args to the ``sampler`` callable).  The same logic applies for :doc:`predict_many<predict-many>`.
 

--- a/docs/source/use-cases.rst
+++ b/docs/source/use-cases.rst
@@ -14,7 +14,7 @@ Common computational challenges in satellite and weather data machine learning i
 
 To address these challenges ``elm`` draws from existing Python packages:
 
-.. _xarray: http://xarray.pydata.org/
+.. _xarray: http://xarray.pydata.org/en/stable/
 
 .. _scikit-learn: http://scikit-learn.org/stable/
 
@@ -24,12 +24,15 @@ To address these challenges ``elm`` draws from existing Python packages:
 
 .. _deap: https://deap.readthedocs.io/en/master/
 
- * `xarray`_
- * `scikit-learn`_
- * `dask`_
- * `numba`_
- * `deap`_
+.. _dask-distributed: http://distributed.readthedocs.io/en/latest/
 
+.. _estimator interface: http://scikit-learn.org/stable/developers/contributing.html#rolling-your-own-estimator
+
+.. _xarray data structures: http://xarray.pydata.org/en/stable/data-structures.html
+
+* `dask-distributed`_: ``elm`` uses `dask-distributed`_ for parallelism over ensemble fitting and prediction
+* `scikit-learn`_ : ``elm`` can use unsupervised and supervised models, preprocessors, scoring functions, and postprocessors from ``scikit-learn`` or any estimator that follows the `scikit-learn` initialize / fit / predict `estimator interface`_.
+* `xarray`_ : ``elm`` wraps `xarray data structures`_ for n-dimensional arrays, such as 3-dimensional weather cubes, and for collections of 2-D rasters, such as a LANDSAT sample
 
 .. _large-scale-model:
 
@@ -46,14 +49,6 @@ Large-Scale Model Training
 * Custom user-given model selection logic in ensemble approaches to training
 
 ``elm`` can use ``dask`` to parallelize the activities above.
-
-More reading:
-
- * :doc:`Pipeline<pipeline>`
- * :doc:`fit_ensemble<fit-ensemble>`
- * :doc:`fit_ea<fit-ea>`
- * :doc:`predict_many<predict-many>`
- * :doc:`Environment variables<environment-vars>`.
 
 .. _model-uncertainty:
 
@@ -119,8 +114,17 @@ Predicting for Many Large Samples and/or Models
 ``elm`` can use dask-distributed, a dask thread pool, or serial processing for predicting over a group (ensemble) of models and a single sample or series of samples.  ``elm``'s interface for large scale prediction, described here, is via the :doc:`predict_many<predict-many>` method of a ``Pipeline`` instance.
 
 
-``elm`` is a Work in Progress
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``elm`` is immature and largely for experimental use.
+``elm`` Capabilities
+--------------------
 
-The developers do not promise backwards compatibility with future versions.
+* :doc:`Ensemble learning<fit-ensemble>`
+* :doc:`Large scale prediction<predict-many>`
+* :doc:`Genetic algorithms<fit-ea>`
+* :doc:`Common preprocessing operations for satellite imagery and climate data<pipeline-steps>`
+
+These capabilities are best shown in the
+
+ * :doc:`Elm introduction<elm-hello-world>`
+ * :doc:`Elm clustering introduction<clustering_example>`
+ * :doc:`Other elm examples<examples>`
+ * :doc:`Use cases<use-cases>`


### PR DESCRIPTION
This PR adds cleanups to the documentation, reorganizes its structure to be more user-friendly, and adds testing for the code snippets to ensure that they remain accurate.

There is now an `environment.yml` file so that we can build the docs and test them within a conda env. I also wrote a convenience script called `autoreload_docs.py` which aids documentation development by watching the doc sources for changes and automatically rebuilding the Sphinx output when an rst file is modified.

Code snippet testing uses the `doctest` extension for Sphinx: http://www.sphinx-doc.org/en/stable/ext/doctest.html . Currently doctests are only written for the "Quick Start" section, but tests can be added to other sections in a similar manner. I put off adding tests for _all_ code blocks because some rely on files being downloaded, or are slightly more involved to test. However we can always add them later on (time permitting).

@PeterDSteinberg if you get the chance, could you please read over some of my wording changes for describing `elm`'s functionality, and confirm that they're accurate?