### PR TITLE
Add back requirements-docs.txt for RTD

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,4 @@
+recommonmark
+sphinx
+sphinx_rtd_theme
+numpydoc


### PR DESCRIPTION
readthedocs.org requires this file to build properly.