### PR TITLE
Do not assume .canvas exists; temporary scoring fixes for supervised models

### DIFF
--- a/elm/model_selection/kmeans.py
+++ b/elm/model_selection/kmeans.py
@@ -18,6 +18,8 @@ from deap.tools.emo import selNSGA2
 import numpy as np
 import pandas as pd
 from sklearn.cluster import KMeans, MiniBatchKMeans
+import xarray as xr
+
 from elm.config.func_signatures import (get_args_kwargs_defaults,
                                         filter_kwargs_to_func)
 
@@ -36,7 +38,10 @@ def kmeans_aic(model, X, **kwargs):
     '''
 
     k, m = model._estimator.cluster_centers_.shape
-    n = X.flat.values.shape[0]
+    if isinstance(X, xr.DataArray):
+        n = X.flat.values.shape[0]
+    else:
+        n = X.shape[0]
     d = model._estimator.inertia_
     aic =  d + 2 * m * k
     delattr(model._estimator, 'labels_')

--- a/elm/pipeline/pipeline.py
+++ b/elm/pipeline/pipeline.py
@@ -185,7 +185,9 @@ class Pipeline(object):
             return pred
         output = fitter_or_predict(*args, **kwargs)
         if sklearn_method in ('fit', 'partial_fit', 'fit_predict'):
-            self._score_estimator(*args, **kwargs)
+            kw = kwargs.copy()
+            kw.update(self.scoring_kwargs.copy())
+            self._score_estimator(*args, **kw)
             return self
         # transform or fit_transform most likely
         return _split_pipeline_output(output, X, y, sample_weight, 'fit_transform')
@@ -554,14 +556,14 @@ class Pipeline(object):
                  saved_model_tag=saved_model_tag)
 
 
-    def _score_estimator(self, X, y=None, sample_weight=None):
+    def _score_estimator(self, X, y=None, sample_weight=None, **kw):
         '''Run the scoring function with scoring_kwargs that were given in __init__
         '''
         if not self.scoring:
             if self.scoring_kwargs:
                 raise ValueError("scoring_kwargs ignored if scoring is not given")
             return
-        kw = self.scoring_kwargs or {}
+        kw = kw.copy()
         kw['y'] = y
         kw['sample_weight'] = sample_weight
         fit_args = (X,)

--- a/elm/pipeline/predict_many.py
+++ b/elm/pipeline/predict_many.py
@@ -49,6 +49,7 @@ def _predict_one_sample_one_arg(estimator,
     attrs.update(X_final.flat.attrs)
     attrs['elm_predict_date'] = datetime.datetime.utcnow().isoformat()
     attrs['band_order'] = ['predict',]
+    attrs['canvas'] = getattr(X_final.flat, 'canvas', None)
     logger.debug('Predict X shape {} X.flat.dims {} '
                  '- y shape {}'.format(X_final.flat.shape, X_final.flat.dims, prediction.shape))
     prediction = ElmStore({'flat': xr.DataArray(prediction,
@@ -56,9 +57,10 @@ def _predict_one_sample_one_arg(estimator,
                                              ('band', bands)],
                                      dims=('space', 'band'),
                                      attrs=attrs)},
-                             attrs=attrs)
+                             attrs=attrs,
+                             add_canvas=False)
     if to_raster:
-        new_es = inverse_flatten(prediction)
+        new_es = inverse_flatten(prediction, add_canvas=False)
     else:
         new_es = prediction
     if serialize:

--- a/elm/sample_util/sample_pipeline.py
+++ b/elm/sample_util/sample_pipeline.py
@@ -267,7 +267,7 @@ def final_on_sample_step(fitter,
         logger.debug('X (shape {})'.format(X_values.shape))
     check_array(X_values, "final_on_sample_step - X")
     if has_y:
-        if not y.size == X_values.shape[0]:
+        if y.size != X_values.shape[0]:
             raise ValueError("Bad size for y ({}) - does not match X.shape[0] ({})".format(y.size, X_values.shape[0]))
     if has_sw:
         if not sample_weight.size == X_values.shape[0]:

--- a/examples/LANDSAT-Population-Model.ipynb
+++ b/examples/LANDSAT-Population-Model.ipynb
@@ -149,20 +149,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "scheduler = os.environ.get('DASK_SCHEDULER')\n",
-    "if not scheduler:\n",
-    "    client = Client()\n",
-    "else:\n",
-    "    client = Client(scheduler)"
+    "scheduler = os.environ.get('DASK_SCHEDULER', '172.31.98.124:8786')\n",
+    "client = Client(scheduler)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "import dask.dataframe as dd\n",
@@ -224,7 +225,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -255,7 +258,7 @@
     "        band_resamp = aggregate(img, aggregator=ds.mean(band), width=w, height=h, dynamic=False)\n",
     "        X_resamp[band] = getattr(band_resamp.data, band)\n",
     "    X_resamp = xr.Dataset(X_resamp, attrs=X.attrs)\n",
-    "    y = people_counts.data.Count.values\n",
+    "    y = people_counts.data.Count.values.ravel()\n",
     "    return (X_resamp, y, None)\n",
     "\n",
     "bin_pop = steps.ModifySample(binning_population)"
@@ -315,33 +318,6 @@
     "    y = sample_weight = None\n",
     "    return (X, y, sample_weight)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X, _, _ = sampler(download_url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -427,28 +403,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Preprocessing example\n",
-    "\n",
-    "Later this notebook using `elm.pipeline.Pipeline` to automate a series of transforms like the one below.  The cell below sets `NaN` values to no-data regions, then converts digital numbers to radiance."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "X, _, _ = sampler(download_url)\n",
-    "Xnew, _, _ = set_nans_step.fit_transform(X)\n",
-    "Xnew, _, _ = reflectance_step.fit_transform(Xnew)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Normalized differences between bands\n",
     "\n",
     "Normalized differences between band reflectances may be helpful in feature engineering to differentiate water, urban areas and forests.\n",
@@ -478,39 +432,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "download_url = clear_image.download_url.values[0]\n",
-    "\n",
-    "X, y, _ = sampler(download_url)\n",
-    "assert y is None\n",
-    "Xnew, y, _ = convert_coords_step.fit_transform(X, y)\n",
-    "assert y is None\n",
-    "Xnew, y, _ = bin_pop.fit_transform(Xnew, y)\n",
-    "assert y is not None\n",
-    "Xnew, y, _ = set_nans_step.fit_transform(Xnew, y)\n",
-    "assert y is not None\n",
-    "Xnew, y, _ = reflectance_step.fit_transform(Xnew, y)\n",
-    "assert y is not None\n",
-    "Xnew, y, _ = normed_diffs_step.fit_transform(Xnew, y)\n",
-    "assert y is not None"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Xnew.band_1.shape, y.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,19 +454,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
-   "source": [
-    "dataset = gv.Dataset(cens, kdims=['easting', 'northing'], vdims=['race'])\n",
-    "\n",
-    "xx, yy = Xnew.band_1.x.values, Xnew.band_1.y.values\n",
-    "#x_range, y_range = ((-13884029.0, -7453303.5), (2818291.5, 6335972.0)) # Continental USA\n",
-    "x_range, y_range = ((np.min(xx), np.max(xx)), (np.min(yy), np.max(yy))) # Chesapeake Bay region LANDSAT 15 / 033\n",
-    "shade_defaults = dict(x_range=x_range, y_range=y_range, x_sampling=10, y_sampling=10, width=800, height=455)\n",
-    "\n",
-    "shaded = datashade(hv.Points(dataset),  cmap=color_key, aggregator=ds.count_cat('race'), **shade_defaults)\n",
-    "shaded"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -644,6 +557,68 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "download_url = clear_image.download_url.values[0]\n",
+    "\n",
+    "X, y, _ = sampler(download_url)\n",
+    "assert y is None\n",
+    "Xnew, y, _ = convert_coords_step.fit_transform(X, y)\n",
+    "assert y is None\n",
+    "Xnew, y, _ = bin_pop.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "Xnew, y, _ = set_nans_step.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "assert y.size == Xnew.band_1.values.size\n",
+    "Xnew, y, _ = reflectance_step.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "Xnew, y, _ = normed_diffs_step.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "Xnew, y, _ = choose_bands_step.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "Xnew, y, _ = flat.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "assert y.size == Xnew.flat.values.shape[0]\n",
+    "Xnew, y, _ = drop_na.fit_transform(Xnew, y)\n",
+    "assert y.size == Xnew.flat.values.shape[0] # TODO these assertions would be a good unit test\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "Xnew.flat.shape, y.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dataset = gv.Dataset(cens, kdims=['easting', 'northing'], vdims=['race'])\n",
+    "\n",
+    "xx, yy = X.band_1.x.values, X.band_1.y.values\n",
+    "#x_range, y_range = ((-13884029.0, -7453303.5), (2818291.5, 6335972.0)) # Continental USA\n",
+    "x_range, y_range = ((np.min(xx), np.max(xx)), (np.min(yy), np.max(yy))) # Chesapeake Bay region LANDSAT 15 / 033\n",
+    "shade_defaults = dict(x_range=x_range, y_range=y_range, x_sampling=10, y_sampling=10, width=800, height=455)\n",
+    "\n",
+    "shaded = datashade(hv.Points(dataset),  cmap=color_key, aggregator=ds.count_cat('race'), **shade_defaults)\n",
+    "shaded"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -675,11 +650,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LinearRegression\n",
     "reg = LinearRegression()\n",
+    "def scoring(model, X, y=None, sample_weight=None, **kwargs):\n",
+    "    return model._estimator.score(X, y)\n",
     "reg_pipe = Pipeline([\n",
     "                 ('convert_coords', convert_coords_step),\n",
     "                 ('set_nans', set_nans_step),\n",
@@ -692,6 +671,7 @@
     "                 ('standard', standardize),\n",
     "                 ('pca', pca),\n",
     "                 ('est', reg)],\n",
+    "                scoring=scoring,\n",
     "                scoring_kwargs=dict(score_weights=[1]))"
    ]
   },
@@ -717,11 +697,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "X, _, _ = sampler(download_url)\n",
-    "fitted = reg_pipe.fit_ensemble(X=X)"
+    "fitted = reg_pipe.fit_ensemble(X=X, client=client)"
    ]
   },
   {
@@ -733,6 +727,17 @@
     " * Uses `distributed` for parallelism\n",
     " * Can return xarray data structure or serialize it\n",
     " * By default, reshapes 1-D predictions to 2-D spatial arrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "preds = reg_pipe.predict_many(X=X, client=client)"
    ]
   },
   {
@@ -796,11 +801,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "pipe_level_2.fit_ensemble(X=X_layer_2, ngen=1, init_ensemble_size=1)\n",
-    "preds2 = pipe_level_2.predict_many(X=X_layer_2)\n",
+    "preds2 = pipe_level_2.predict_many(X=X_layer_2, y=y)\n",
     "len(preds2)"
    ]
   },
@@ -817,6 +824,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -831,7 +839,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -839,6 +849,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -854,7 +865,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "X.band_order, X_resamp.band_order"
@@ -863,7 +876,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "X_resamp.band_1"
@@ -872,7 +887,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "population_y = people_counts.data.Count.values"
@@ -881,7 +898,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "population_y.shape"
@@ -909,6 +928,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -917,21 +937,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "download_url"

--- a/examples/LANDSAT-Population-Model.ipynb
+++ b/examples/LANDSAT-Population-Model.ipynb
@@ -1,0 +1,971 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LANDSAT and Ensemble Learning Models\n",
+    "\n",
+    "[Ensemble Learning Models (Elm)](https://github.com/ContinuumIO/elm) was developed for a 2016 NASA SBIR Phase I.  Elm provides large data machine learning tools for satellite imagery and climate data.\n",
+    "\n",
+    " * Using the AWS S3 LANDSAT data\n",
+    " * Using GeoTiff metadata\n",
+    " * Feature engineering with `elm.pipeline.Pipeline`\n",
+    " * Fitting / predicting with `distributed`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "conda env create --name ds-35\n",
+    "source activate ds-35\n",
+    "conda install -c elm/label/dev -c elm -c conda-forge -c ioam -c conda-forge -c scitools/label/dev python=3.5 elm earthio pyarrow fastparquet\n",
+    "conda remove bokeh ; conda install bokeh\n",
+    "jupyter notebook\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import glob\n",
+    "import os\n",
+    "import re\n",
+    "import sys\n",
+    "from urllib.request import urlopen\n",
+    "\n",
+    "from bokeh.models import WMTSTileSource\n",
+    "from cartopy import crs\n",
+    "from collections import defaultdict, OrderedDict\n",
+    "from dask.diagnostics import ProgressBar\n",
+    "from dask.distributed import Client\n",
+    "from earthio import load_array, load_tif_meta, BandSpec, ElmStore\n",
+    "from earthio.landsat_util import landsat_metadata\n",
+    "from earthio.s3_landsat_util import SceneDownloader\n",
+    "from elm.model_selection.kmeans import kmeans_aic, kmeans_model_averaging\n",
+    "from elm.pipeline import Pipeline, steps\n",
+    "from holoviews.operation import decimate\n",
+    "from holoviews.operation.datashader import aggregate, shade, datashade, dynspread\n",
+    "from matplotlib.cm import get_cmap\n",
+    "from pyproj import Proj, transform\n",
+    "from sklearn.cluster import MiniBatchKMeans\n",
+    "from sklearn.decomposition import PCA\n",
+    "import dask\n",
+    "import dask.dataframe as dd\n",
+    "import datashader as ds\n",
+    "import datashader.transfer_functions as tf\n",
+    "import dill\n",
+    "import geoviews as gv\n",
+    "import holoviews as hv\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import rasterio as rio\n",
+    "import requests\n",
+    "import xarray as xr\n",
+    "\n",
+    "hv.notebook_extension('bokeh')\n",
+    "decimate.max_samples = 1000\n",
+    "dynspread.max_px = 20\n",
+    "dynspread.threshold = 0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## S3 LANDSAT downloader\n",
+    "See [this example scene from the AWS S3 LANDSAT store](http://landsat-pds.s3.amazonaws.com/L8/015/033/LC80150332013207LGN00/index.html)\n",
+    "\n",
+    "This example uses `SceneDownloader` to find scenes meeting spatial or cloud cover criteria."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_download = SceneDownloader(s3_tif_dir='data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "?SceneDownloader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GeoTiff options\n",
+    "\n",
+    "Use `elm.readers.BandSpec` to control:\n",
+    "\n",
+    " * Resolution\n",
+    " * Naming of the bands\n",
+    " * Where to find each band's GeoTiff based on file name match"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "BUF_X_SIZE, BUF_Y_SIZE = 600, 600 # Set to 800, 800 for 800 by 800 pix decimation\n",
+    "BAND_SPECS = [BandSpec(search_key='name',\n",
+    "                       search_value='B{}.TIF'.format(band),\n",
+    "                       name='band_{}'.format(band),\n",
+    "                       buf_xsize=BUF_X_SIZE,\n",
+    "                       buf_ysize=BUF_Y_SIZE) for band in range(1, 8)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create `distributed.Client`\n",
+    "\n",
+    " * Defaults to creation of local scheduler / workers\n",
+    " * Can point to remote scheduler / workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scheduler = os.environ.get('DASK_SCHEDULER')\n",
+    "if not scheduler:\n",
+    "    client = Client()\n",
+    "else:\n",
+    "    client = Client(scheduler)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "cens = dd.io.parquet.read_parquet('data/census.snappy.parq', )\n",
+    "cens = cens.persist()\n",
+    "cens.columns, cens[['easting', 'northing']].min().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "FT_2_M = 0.3048    \n",
+    "def convert_coords(X, y=None, sample_weight=None, metric=True, **kwargs):\n",
+    "    landsat = Proj(**X.band_1.meta['crs'])  \n",
+    "    web_mercator = Proj(init='epsg:3857')             # Mercator projection EPSG code\n",
+    "    scale = 1.0 if metric else FT_2_M\n",
+    "    xx, yy = transform(landsat, web_mercator, X.band_1.x.values * scale, X.band_1.y.values * scale)\n",
+    "    for band in X.band_order:\n",
+    "        b = getattr(X, band)\n",
+    "        b.x.values[:] = xx\n",
+    "        b.y.values[:] = yy\n",
+    "    return (X, y, sample_weight)\n",
+    "convert_coords_step = steps.ModifySample(convert_coords)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get corresponding population"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "cens = dd.io.parquet.read_parquet('data/census.snappy.parq')\n",
+    "cens = cens.persist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def binning_population(X, y=None, sample_weight=None, **kwargs):\n",
+    "    xx, yy = X.band_1.x.values, X.band_1.y.values\n",
+    "    subset = cens[(cens.easting <= np.max(xx))&\n",
+    "              (cens.easting >= np.min(xx))& \n",
+    "              (cens.northing <= np.max(yy))&\n",
+    "              (cens.northing >= np.min(yy))]\n",
+    "    people_counts = None\n",
+    "    X_resamp = {}\n",
+    "    h, w = X.band_1.shape\n",
+    "    for b in range(1, 8):\n",
+    "        band = 'band_' + str(b)\n",
+    "        band_existing = getattr(X, band)\n",
+    "        img = hv.Image(band_existing, vdims=[band])\n",
+    "        if people_counts is None:\n",
+    "            people_counts = aggregate(hv.Points(subset), x_range=img.range(0), y_range=img.range(1), width=w, height=h, dynamic=False)\n",
+    "        aggregate(img, aggregator=ds.mean(band), width=w, height=h, dynamic=False)\n",
+    "        band_resamp = aggregate(img, aggregator=ds.mean(band), width=w, height=h, dynamic=False)\n",
+    "        X_resamp[band] = getattr(band_resamp.data, band)\n",
+    "    X_resamp = xr.Dataset(X_resamp, attrs=X.attrs)\n",
+    "    y = people_counts.data.Count.values\n",
+    "    return (X_resamp, y, None)\n",
+    "\n",
+    "bin_pop = steps.ModifySample(binning_population)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finding a cloud free image\n",
+    "\n",
+    "(For a given LANDSAT row / path and month)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clear_image = s3_download.lowest_cloud_cover_image(row=33, path=15, months=tuple(range(1,13)))\n",
+    "clear_image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_url = clear_image.download_url.values[0]\n",
+    "download_url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## LANDSAT `sampler` function\n",
+    " * Uses `elm.readers.load_array` with `band_specs` argument\n",
+    " * Adds MTL file metadata with `elm.readers.landsat_util.landsat_metadata`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def sampler(download_url, **kwargs):\n",
+    "    local_files = s3_download.download_all_bands(download_url)\n",
+    "    this_sample_dir = os.path.dirname(local_files[0])\n",
+    "    X = load_array(this_sample_dir, band_specs=BAND_SPECS)\n",
+    "    X.attrs.update(vars(landsat_metadata([f for f in local_files if f.endswith('.txt')][0])))\n",
+    "    y = sample_weight = None\n",
+    "    return (X, y, sample_weight)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X, _, _ = sampler(download_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert digital numbers to radiance or reflectance\n",
+    "\n",
+    "Generalize the example given in the plot above to allow TOA radiance or reflectance for any band:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from functools import partial\n",
+    "def toa_rad_or_reflect(X, y=None, sample_weight=None,**kw):\n",
+    "    rad_or_reflect = kw['rad_or_reflect']\n",
+    "    for band in X.data_vars:\n",
+    "        num = band.split('_')[-1]\n",
+    "        add = getattr(X, '{}_ADD_BAND_{}'.format(rad_or_reflect, num))\n",
+    "        mult = getattr(X, '{}_MULT_BAND_{}'.format(rad_or_reflect, num))\n",
+    "        band_arr = getattr(X, band)\n",
+    "        band_arr.values[:] = band_arr.values * mult + add\n",
+    "        if rad_or_reflect == 'REFLECTANCE':\n",
+    "            band_arr.values = band_arr.values / np.sin(X.SUN_ELEVATION * (np.pi / 180.))\n",
+    "    return (X, y, sample_weight)\n",
+    "toa_radiance = partial(toa_rad_or_reflect, rad_or_reflect='RADIANCE')\n",
+    "toa_reflectance = partial(toa_rad_or_reflect, rad_or_reflect='REFLECTANCE')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Set `NaN` values for no-data regions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def set_nans(X, y=None, sample_weight=None, **kwargs):\n",
+    "    xx = X.copy(deep=True)\n",
+    "    for band in xx.data_vars:\n",
+    "        band_arr = getattr(xx, band)\n",
+    "        band_arr.values = band_arr.values.astype(np.float32)\n",
+    "        band_arr.values[band_arr.values <= 1] = np.NaN\n",
+    "        band_arr.values[band_arr.values == 2**16] = np.NaN\n",
+    "    return (xx, y, sample_weight)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `elm.pipeline.steps.ModifySample`\n",
+    " * Use custom functions in an `elm.pipeline.Pipeline` of transformations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "set_nans_step = steps.ModifySample(set_nans)\n",
+    "reflectance_step = steps.ModifySample(toa_reflectance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preprocessing example\n",
+    "\n",
+    "Later this notebook using `elm.pipeline.Pipeline` to automate a series of transforms like the one below.  The cell below sets `NaN` values to no-data regions, then converts digital numbers to radiance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "X, _, _ = sampler(download_url)\n",
+    "Xnew, _, _ = set_nans_step.fit_transform(X)\n",
+    "Xnew, _, _ = reflectance_step.fit_transform(Xnew)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Normalized differences between bands\n",
+    "\n",
+    "Normalized differences between band reflectances may be helpful in feature engineering to differentiate water, urban areas and forests.\n",
+    "\n",
+    " * NDWI - Normalized Difference Water Index\n",
+    " * NDVI - Normalized Difference Vegetation Index\n",
+    " * NDSI - Normalized Difference Soil Index\n",
+    " * NBR - Normalized Burn Ratio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "normalized_diffs = {'ndwi': ('band_4', 'band_5'),\n",
+    "                    'ndvi': ('band_5', 'band_4'),\n",
+    "                    'ndsi': ('band_2', 'band_6'),\n",
+    "                    'nbr':  ('band_4', 'band_7'),\n",
+    "                 }\n",
+    "normed_diffs_step = steps.NormedBandsDiff(spec=normalized_diffs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "download_url = clear_image.download_url.values[0]\n",
+    "\n",
+    "X, y, _ = sampler(download_url)\n",
+    "assert y is None\n",
+    "Xnew, y, _ = convert_coords_step.fit_transform(X, y)\n",
+    "assert y is None\n",
+    "Xnew, y, _ = bin_pop.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "Xnew, y, _ = set_nans_step.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "Xnew, y, _ = reflectance_step.fit_transform(Xnew, y)\n",
+    "assert y is not None\n",
+    "Xnew, y, _ = normed_diffs_step.fit_transform(Xnew, y)\n",
+    "assert y is not None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Xnew.band_1.shape, y.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ProgressBar().register()\n",
+    "\n",
+    "hv.notebook_extension('bokeh', width=95)\n",
+    "\n",
+    "%opts Overlay [width=800 height=455 xaxis=None yaxis=None show_grid=False] \n",
+    "%opts RGB     [width=800 height=455 xaxis=None yaxis=None show_grid=False] \n",
+    "%opts Shape (fill_color=None line_width=1.5) [apply_ranges=False] \n",
+    "%opts Points [apply_ranges=False] WMTS (alpha=0.5) NdOverlay [tools=['tap']]\n",
+    "color_key = {'w':'blue',  'b':'green', 'a':'red',   'h':'orange',   'o':'saddlebrown'}\n",
+    "races     = {'w':'White', 'b':'Black', 'a':'Asian', 'h':'Hispanic', 'o':'Other'}\n",
+    "\n",
+    "color_points = hv.NdOverlay({races[k]: gv.Points([0,0], crs=crs.PlateCarree(),\n",
+    "                                 label=races[k])(style=dict(color=v))\n",
+    "                             for k, v in color_key.items()})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = gv.Dataset(cens, kdims=['easting', 'northing'], vdims=['race'])\n",
+    "\n",
+    "xx, yy = Xnew.band_1.x.values, Xnew.band_1.y.values\n",
+    "#x_range, y_range = ((-13884029.0, -7453303.5), (2818291.5, 6335972.0)) # Continental USA\n",
+    "x_range, y_range = ((np.min(xx), np.max(xx)), (np.min(yy), np.max(yy))) # Chesapeake Bay region LANDSAT 15 / 033\n",
+    "shade_defaults = dict(x_range=x_range, y_range=y_range, x_sampling=10, y_sampling=10, width=800, height=455)\n",
+    "\n",
+    "shaded = datashade(hv.Points(dataset),  cmap=color_key, aggregator=ds.count_cat('race'), **shade_defaults)\n",
+    "shaded"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Selecting bands for learning\n",
+    "The following function could allow hyperparameterization to control which bands and normalized differences become input features to machine learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "NORMALIZED_DIFFS = ('nbr', 'ndsi', 'ndwi', 'ndvi')\n",
+    "DEFAULT_BANDS = [band_spec.name for band_spec in BAND_SPECS]\n",
+    "def choose_bands(X, y=None, sample_weight=None, **kwargs):\n",
+    "    new = {}\n",
+    "    bands = kwargs.get('bands', DEFAULT_BANDS)\n",
+    "    include_normed_diffs = kwargs.get('include_normed_diffs', True)\n",
+    "    for band in bands:\n",
+    "        data_arr = getattr(X, band)\n",
+    "        new[band] = data_arr\n",
+    "    if include_normed_diffs:\n",
+    "        for diff in NORMALIZED_DIFFS:\n",
+    "            new[diff] = getattr(X, diff)\n",
+    "    ks = list(new)\n",
+    "    es = ElmStore({k: new[k] for k in ks}, add_canvas=False)\n",
+    "    for band in es.data_vars:\n",
+    "        es[band].attrs['canvas'] = data_arr.canvas\n",
+    "    es.attrs.update(X.attrs)\n",
+    "    print('Chose', es.data_vars)\n",
+    "    return (es, y, sample_weight)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using `elm.pipeline.steps` for preprocessing\n",
+    "The next cell allows a custom function to be used in a `Pipeline`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "choose_bands_step = steps.ModifySample(choose_bands,\n",
+    "                              bands=DEFAULT_BANDS,\n",
+    "                              include_normed_diffs=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These steps flatten rasters to columns and remove no-data pixels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "flat = steps.Flatten()\n",
+    "drop_na = steps.DropNaRows()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These steps using `sklearn.preprocessing.StandardScaler` to normalize data and `PCA` to reduce dimensionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "standardize = steps.StandardScaler()\n",
+    "pca = steps.Transform(PCA(n_components=5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  `scikit-learn` estimator\n",
+    "\n",
+    "The final step in `Pipeline` is a `scikit-learn` estimator."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Controlling ensemble initialization\n",
+    "\n",
+    "Starting with a group of `8` `Pipeline` instances with varying PCA and K-Means parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import LinearRegression\n",
+    "reg = LinearRegression()\n",
+    "reg_pipe = Pipeline([\n",
+    "                 ('convert_coords', convert_coords_step),\n",
+    "                 ('set_nans', set_nans_step),\n",
+    "                 ('population', bin_pop),\n",
+    "                 ('reflect', reflectance_step),\n",
+    "                 ('normed_diffs', normed_diffs_step),\n",
+    "                 ('choose', choose_bands_step),\n",
+    "                 ('flat', flat),\n",
+    "                 ('drop_na', drop_na),\n",
+    "                 ('standard', standardize),\n",
+    "                 ('pca', pca),\n",
+    "                 ('est', reg)],\n",
+    "                scoring_kwargs=dict(score_weights=[1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run `fit_ensemble`\n",
+    " * Control number of fitting generations\n",
+    " * Control model selection\n",
+    " * Control ensemble initialization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X, _, _ = sampler(download_url)\n",
+    "fitted = reg_pipe.fit_ensemble(X=X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `Pipeline.predict_many`\n",
+    " * Predicts for one or more samples and one or more ensemble members\n",
+    " * Uses `distributed` for parallelism\n",
+    " * Can return xarray data structure or serialize it\n",
+    " * By default, reshapes 1-D predictions to 2-D spatial arrays"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps - Hierarchical Modeling\n",
+    "\n",
+    "Notice in the predictions plotted above, most ensemble members arrived at similar clustering systems, but:\n",
+    "\n",
+    "* The clusters were named differently in each model (i.e. cluster #1 is not the same in every ensemble member).\n",
+    "* The models differed in the water region of the image (Chesapeake Bay) with some models finding two in-water clusters and other models finding one\n",
+    "\n",
+    "Future development with `elm` will automate the following cells' steps of predicting based on an ensemble of predictions.  The steps are to:\n",
+    "\n",
+    "* Flatten all predictions\n",
+    "* Use a categorical to binary encoder\n",
+    "* Predict with K-Means based on the ensemble members' encoded predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import OneHotEncoder\n",
+    "def sampler_layer_2(preds):\n",
+    "    # This will be simplified in Hierarchical modeling / vote count tasks\n",
+    "    predicts = []\n",
+    "    for p in preds:\n",
+    "        flat, _, _ = steps.Flatten().fit_transform(p.copy(deep=True))\n",
+    "        no_na, _, _ = steps.DropNaRows().fit_transform(flat)\n",
+    "        predicts.append(no_na.flat.values[:,0])\n",
+    "    transformed = OneHotEncoder().fit_transform(np.array(predicts).T).todense()\n",
+    "    Xnew = ElmStore({'flat': xr.DataArray(transformed, \n",
+    "                                          coords=[('space', no_na.space), \n",
+    "                                                  ('band', np.arange(transformed.shape[1]))],\n",
+    "                                         dims=('space','band'))},\n",
+    "                    attrs=no_na.attrs)\n",
+    "    return Xnew\n",
+    "X_layer_2 = sampler_layer_2(preds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick a number of clusters to use (randomly)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit and predict based on ensemble of predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe_level_2.fit_ensemble(X=X_layer_2, ngen=1, init_ensemble_size=1)\n",
+    "preds2 = pipe_level_2.predict_many(X=X_layer_2)\n",
+    "len(preds2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot prediction from hierarchical model\n",
+    "\n",
+    "This shows some of the Phase II idea of hierarchical models (models on predictions from ensembles)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# TODO Legend\n",
+    "%opts Image [width=800 height=600]\n",
+    "%opts Layout [tabs=True]\n",
+    "best = preds2[0]\n",
+    "hv.Image(best, kdims=['x', 'y'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "#img = hv.Image(X.band_1)\n",
+    "#agg = aggregate(hv.Points(subset), target=img, dynamic=False)\n",
+    "\n",
+    "#ds = xr.Dataset({'Population': agg.data.Count, 'Band_1': X.band_1})\n",
+    "#df = ds.to_dataframe()\n",
+    "#ds = xr.Dataset({'Population': agg.data.Count, 'Band_1': agg2.data.band_1})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X.band_order, X_resamp.band_order"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_resamp.band_1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "population_y = people_counts.data.Count.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "population_y.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/LANDSAT_Example-Datashader.ipynb
+++ b/examples/LANDSAT_Example-Datashader.ipynb
@@ -400,8 +400,8 @@
    },
    "outputs": [],
    "source": [
-    "%%opts RGB [width=800 height=600]\n",
-    "scale = 0.2\n",
+    "%opts RGB [width=800 height=600]\n",
+    "scale = 1\n",
     "bands_432 = ['band_4', 'band_3', 'band_2']\n",
     "hv.RGB(xr.Dataset({band: getattr(Xnew, band) / scale for band in bands_432}), \n",
     "       kdims=['x', 'y'])"
@@ -1112,10 +1112,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Image [width=800 height=600]\n",
-    "%%opts Layout [tabs=True]\n",
+    "%opts Image [width=800 height=600]\n",
+    "%opts Layout [tabs=True ]\n",
     "best = preds2[0]\n",
-    "hv.Image(best, kdims=['x', 'y'])"
+    "hv.Image(best, kdims=['x', 'y'], group='Land Cover / Land Use Map (K-Means Ensemble)')"
    ]
   },
   {


### PR DESCRIPTION
* [x] Fixes a bug in `predict_many.py` regarding assumptions about the `.canvas` attribute (part of the work towards issue #100 of having more data structure flexibility
* [x] Makes a TODO list in `elm.model_selection.scoring` regarding improvements needed in scoring when we address issue #99 .  Those issues are summarized for now in a TODO in the code in case we have confusion building notebooks before #99 is addressed.  That TODO mentions: the `elm.model_selection.scoring` functions needs refactor and docs explanation.  They are brittle and difficult to use:
     * Unclear how to pass in a custom scorer:
        * Do I need to call `make_scorer()` myself on that function
        * If I need to call `make_scorer()`, do I use the `elm.model_selection.scoring.make_scorer` above or the `make_scorer` from `sklearn.metrics`?
     * Should a scoring function expect the model to be passed into it, and if so, do should I expect always a `Pipeline` instance from the `elm` stack or the `Pipeline`'s `_estimator` attribute that is typically an `sklearn` model like `LinearRegression()`
    * Should my `scoring` function, whether custom or standard like `r2_score`, expect that `X` and `y` are `xarray` data structures or `numpy` ones that have been already prepared for use with the final sklearn estimator