### PR TITLE
Pipeline text specification and CV cache ideas

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,7 +14,6 @@ requirements:
     - setuptools
 
   run:
-    - attrs
     - deap
     - dill
     - distributed

--- a/elm/mldataset/cv_cache.py
+++ b/elm/mldataset/cv_cache.py
@@ -1,0 +1,93 @@
+from dask_searchcv.methods import CVCache
+class CVCacheSampleId(CVCache):
+    def __init__(self, splits, sampler, pairwise=False, cache=True):
+
+        self.splits = splits
+        self.pairwise = pairwise
+        self.cache = {} if cache else None
+        self.sampler = sampler
+
+    def extract_param(self, key, x, n):
+        print('extract_param', key, x, n)
+        if self.cache is not None and (n, key) in self.cache:
+            return self.cache[n, key]
+        out = self.sampler(self.splits[n][0])
+        if self.cache is not None:
+            self.cache[n, key] = out
+        return out
+
+    def extract(self, X, y, n, is_x=True, is_train=True):
+        print('extract', X, y, n, is_x, is_train)
+        if self.cache is not None and (n, is_x, is_train) in self.cache:
+            return self.cache[n, is_x, is_train]
+
+        inds = self.splits[n][0] if is_train else self.splits[n][1]
+        result = self.sampler(inds)
+        if isinstance(result, (tuple, list)) and len(result) == 2:
+            X, y = result
+        else:
+            X = result
+            y = None
+        if self.cache is not None:
+            self.cache[n, True, is_train] = X
+            self.cache[n, False, is_train] = y
+        return X if is_x else y
+
+    def split(self, X, y, groups):
+        return self.splits
+        print('groups', groups, X, y)
+        if y is None:
+            y = (None,) * len(X)
+        #for train, test in X:
+            #yield train, test
+
+
+
+def cv_split(sampler, cv, X, y, groups, is_pairwise, cache):
+    print('samp', sampler, cv, X, y, groups, is_pairwise, cache)
+    return CVCacheSampleId(list(cv.split(X, y, groups)),
+                           sampler, is_pairwise, cache)
+
+'''
+
+TEST - TODO like the following
+def sampler(filenames):
+    print(filenames)
+
+cv = CVCacheSampleId([['file_1', 'file_2'],
+                      ['file_3', 'file_4']],
+                     sampler=sampler)
+cv.extract('ignore', 'ignore', 0)
+
+
+'''
+'''
+def cv_split(cv, X, y, groups, is_pairwise, cache):
+    return CVCache(list(cv.split(X, y, groups)), is_pairwise, cache)
+
+list(cv.split(X, y, groups))
+
+
+X_train = cv.extract(X, y, n, True, True)
+y_train = cv.extract(X, y, n, False, True)
+X_test = cv.extract(X, y, n, True, False)
+y_test = cv.extract(X, y, n, False, False)
+
+
+    def __reduce__(self):
+        return (CVCache, (self.splits, self.pairwise, self.cache is not None))
+
+    def num_test_samples(self):
+        return np.array([i.sum() if i.dtype == bool else len(i)
+                         for i in pluck(1, self.splits)])
+
+    def extract(self, X, y, n, is_x=True, is_train=True):
+
+        if is_x:
+            if self.pairwise:
+                return self._extract_pairwise(X, y, n, is_train=is_train)
+            return self._extract(X, y, n, is_x=True, is_train=is_train)
+        if y is None:
+            return None
+        return self._extract(X, y, n, is_x=False, is_train=is_train)
+    '''

--- a/elm/mldataset/spec_mixins.py
+++ b/elm/mldataset/spec_mixins.py
@@ -1,0 +1,44 @@
+class SpecMixinBaseEstimator:
+
+    _root = 'elm.pipeline.steps.{}'
+    @property
+    def spec(self):
+        _cls = getattr(self, '_cls', None)
+        if not _cls:
+            _cls = self.__class__
+        name = _cls.__name__
+        module = _cls.__module__.split('.')[1]
+        return dict(name=_cls.__name__,
+                    module=self._root.format(module),
+                    params=self.get_params())
+
+    @classmethod
+    def from_spec(self, spec):
+        modul, name, params = spec['module'], spec['name'], spec['params']
+        parts = modul.split('.')
+        elm = '.'.join(parts[:-1])
+        sk_module = __import__(elm, globals(), locals())
+        for p in parts[1:]:
+            sk_module = getattr(sk_module, p)
+        return getattr(sk_module, name)(**params)
+
+
+class PipelineSpecMixin(SpecMixinBaseEstimator):
+
+    @property
+    def spec(self):
+        steps = [[name, step.spec] for name, step in self.steps]
+        spec = super(PipelineSpecMixin, self).spec
+        spec['steps'] = steps
+        return spec
+
+    @classmethod
+    def from_spec(self, spec):
+        spec = spec.copy()
+        from_spec = super(PipelineSpecMixin, self).from_spec
+        steps = [[name, from_spec(spec)] for name, spec in spec.pop('steps')]
+        return super(PipelineSpecMixin, self).from_spec(**spec)
+
+
+
+

--- a/elm/model_selection/evolve.py
+++ b/elm/model_selection/evolve.py
@@ -61,11 +61,15 @@ DEFAULT_CONTROL = {
       # alternatively 'early_stop': {'threshold': [10], 'agg': any}
     }
 
+try:
+    strings = (str, unicode)
+except:
+    strings = (str,)
 REQUIRED_CONTROL_KEYS_TYPES = {
-    'select_method': str,
-    'crossover_method': str,
-    'mutate_method': str,
-    'init_pop': str,
+    'select_method': strings,
+    'crossover_method': strings,
+    'mutate_method': strings,
+    'init_pop': strings,
     'indpb': float,
     'mutpb': float,
     'cxpb':  float,

--- a/elm/pipeline/pipeline.py
+++ b/elm/pipeline/pipeline.py
@@ -22,6 +22,7 @@ from elm.mldataset.wrap_sklearn import (_as_numpy_arrs,
                                         _from_numpy_arrs,
                                         get_row_index,
                                         SklearnMixin)
+from elm.mldataset.spec_mixins import SpecMixinBaseEstimator
 
 from sklearn.utils.metaestimators import _BaseComposition
 from xarray_filters.pipeline import Step
@@ -30,7 +31,7 @@ from xarray_filters.func_signatures import filter_args_kwargs
 __all__ = ['Pipeline', 'FeatureUnion']
 
 
-class Pipeline(sk_Pipeline):
+class Pipeline(sk_Pipeline, SpecMixinBaseEstimator):
 
     # Estimator interface
 
@@ -129,7 +130,7 @@ class Pipeline(sk_Pipeline):
                 # from the cache.
                 self.steps[step_idx] = (name, fitted_transformer)
         if self._final_estimator is None:
-            return Xt, {}
+            return Xt, {}, fit_params
         fit_params = fit_params_steps[self.steps[-1][0]]
         return Xt, y, fit_params
 

--- a/elm/pipeline/steps.py
+++ b/elm/pipeline/steps.py
@@ -55,6 +55,8 @@ for m in MODULES:
     for cls in get_module_classes(m).values():
         if cls.__name__ in _seen:
             continue
+        if not m in cls.__module__:
+            continue
         _seen.add(cls.__name__)
         w = patch_cls(cls)
         if any(s in cls.__name__ for s in SKIP):


### PR DESCRIPTION
I made this branch regarding experimentation I'm doing with Elm-Earthio-NLDAS repo - I'm using the soil moisture ML model there to break/prototype `elm` and related tools.  This PR has some ideas for the Pipeline/estimator YAML specification and for CV cache ideas related to xarray_filters.  We can open separate branches to get the work done further - this is just to show some ideas.

## YAML -spec
 * See [spec_mixins.py with some ideas for serialization](https://github.com/ContinuumIO/elm/blob/nldas-improve-192/elm/mldataset/spec_mixins.py)
* An example of `.spec` with a `Pipeline` - [shown here in wiki](https://github.com/ContinuumIO/elm/wiki/Yaml-Specification-for-Elm-Pipeline)

A couple fixes in here in addition to the new stuff above
 * `elm.pipeline.steps` was wrapping some classes as they were found by way of imports into other sklearn classes.  
 * removes the installation of `attrs` 
